### PR TITLE
feat: 5 landing page design variants

### DIFF
--- a/src/pages/1.astro
+++ b/src/pages/1.astro
@@ -1,0 +1,146 @@
+---
+import Layout from "@/layouts/Layout.astro";
+
+const features = [
+  {
+    name: "PDF & DOCX Upload",
+    desc: "Drop any resume format — Tailory handles the text extraction.",
+  },
+  {
+    name: "Auto-Parsing",
+    desc: "Heuristic parsing maps raw text into structured JSON Resume fields automatically.",
+  },
+  { name: "Live Preview", desc: "See your resume rendered in real time as you make edits." },
+  {
+    name: "3 Templates",
+    desc: "Modern, Minimal, and Compact ATS — pick the one that fits your field.",
+  },
+  {
+    name: "ATS-Safe Export",
+    desc: "Machine-readable PDFs with no images or tables to confuse applicant tracking systems.",
+  },
+  {
+    name: "Draft Storage",
+    desc: "Your work saves automatically to your browser's local IndexedDB storage.",
+  },
+];
+
+const steps = [
+  {
+    n: "01",
+    title: "Upload",
+    desc: "Drop your existing PDF or DOCX resume, or start from a blank form.",
+  },
+  {
+    n: "02",
+    title: "Edit",
+    desc: "Refine every field in a clean, structured editor. No formatting fights.",
+  },
+  { n: "03", title: "Export", desc: "Download a polished, ATS-compatible PDF in one click." },
+];
+---
+
+<Layout
+  title="Tailory — Dark Editorial"
+  description="A fully client-side resume editor. No server, no account."
+>
+  <div class="min-h-screen bg-[#0a0a0f] font-serif text-[#e8e9f0]">
+    <!-- Nav -->
+    <header class="sticky top-0 z-50 border-b border-[#1e1e2a] bg-[#0a0a0f]">
+      <nav class="mx-auto flex max-w-5xl items-center justify-between px-8 py-5">
+        <span class="text-xl font-semibold tracking-tight text-[#c8cbec]">Tailory</span>
+        <a
+          href="https://github.com/abijith-suresh/tailory"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="font-mono text-sm text-[#6b7098] transition-colors hover:text-[#c8cbec]"
+        >
+          GitHub ↗
+        </a>
+      </nav>
+    </header>
+
+    <!-- Hero -->
+    <section class="mx-auto max-w-5xl px-8 pb-24 pt-28">
+      <p class="mb-8 font-mono text-xs uppercase tracking-[0.15em] text-[#6b7098]">
+        Client-side resume editor
+      </p>
+      <h1 class="mb-8 max-w-3xl text-6xl font-bold leading-[1.08] tracking-tight text-[#e8e9f0]">
+        The resume editor that<br />
+        <em class="not-italic text-[#9ea6d4]">respects your browser.</em>
+      </h1>
+      <p class="mb-10 max-w-xl font-sans text-lg leading-relaxed text-[#8b8fa8]">
+        No server. No account. No data leaves your device. Upload a PDF or DOCX, edit in a
+        structured form, and export an ATS-safe PDF — entirely in your browser.
+      </p>
+      <a
+        href="/editor"
+        class="inline-block bg-[#9ea6d4] px-7 py-3 font-sans text-sm font-semibold text-[#0a0a0f] transition-opacity hover:opacity-90"
+      >
+        Get Started →
+      </a>
+    </section>
+
+    <div class="mx-auto max-w-5xl border-t border-[#1e1e2a] px-8"></div>
+
+    <!-- Features -->
+    <section class="mx-auto max-w-5xl px-8 py-24">
+      <p class="mb-16 font-mono text-xs uppercase tracking-[0.15em] text-[#6b7098]">What it does</p>
+      <div class="grid grid-cols-1 gap-x-16 gap-y-12 md:grid-cols-2">
+        {
+          features.map((f) => (
+            <div>
+              <h3 class="mb-2 text-lg font-semibold tracking-tight text-[#c8cbec]">{f.name}</h3>
+              <p class="font-sans text-sm leading-relaxed text-[#6b7098]">{f.desc}</p>
+            </div>
+          ))
+        }
+      </div>
+    </section>
+
+    <div class="mx-auto max-w-5xl border-t border-[#1e1e2a] px-8"></div>
+
+    <!-- How it works -->
+    <section class="mx-auto max-w-5xl px-8 py-24">
+      <p class="mb-16 font-mono text-xs uppercase tracking-[0.15em] text-[#6b7098]">How it works</p>
+      <div class="grid grid-cols-1 gap-12 md:grid-cols-3">
+        {
+          steps.map((s) => (
+            <div>
+              <p class="mb-6 font-mono text-5xl font-bold text-[#1e2035]">{s.n}</p>
+              <h3 class="mb-2 text-xl font-semibold text-[#c8cbec]">{s.title}</h3>
+              <p class="font-sans text-sm leading-relaxed text-[#6b7098]">{s.desc}</p>
+            </div>
+          ))
+        }
+      </div>
+    </section>
+
+    <!-- Privacy callout -->
+    <div class="border-b border-t border-[#1e1e2a] bg-[#0d0d16]">
+      <div class="mx-auto max-w-5xl px-8 py-20 text-center">
+        <h2 class="mb-4 text-3xl font-bold tracking-tight text-[#9ea6d4]">
+          Your data never leaves your device.
+        </h2>
+        <p class="mx-auto max-w-md font-sans text-base leading-relaxed text-[#6b7098]">
+          No telemetry. No cloud sync. No accounts. Tailory runs entirely in your browser — your
+          resume stays exactly where it belongs: with you.
+        </p>
+      </div>
+    </div>
+
+    <!-- Footer -->
+    <footer
+      class="mx-auto flex max-w-5xl flex-col items-center justify-between gap-4 px-8 py-12 sm:flex-row"
+    >
+      <p class="font-sans text-sm text-[#3a3a52]">© 2025 Tailory</p>
+      <nav class="flex gap-6 font-sans text-sm">
+        <a href="/features" class="text-[#6b7098] transition-colors hover:text-[#c8cbec]"
+          >Features</a
+        >
+        <a href="/about" class="text-[#6b7098] transition-colors hover:text-[#c8cbec]">About</a>
+        <a href="/faq" class="text-[#6b7098] transition-colors hover:text-[#c8cbec]">FAQ</a>
+      </nav>
+    </footer>
+  </div>
+</Layout>

--- a/src/pages/2.astro
+++ b/src/pages/2.astro
@@ -1,0 +1,206 @@
+---
+import Layout from "@/layouts/Layout.astro";
+
+const features = [
+  {
+    icon: "↑",
+    name: "PDF & DOCX Upload",
+    desc: "Drop any resume format — Tailory extracts the text automatically.",
+  },
+  {
+    icon: "⟡",
+    name: "Auto-Parsing",
+    desc: "Heuristic parsing maps raw text into structured JSON Resume fields.",
+  },
+  {
+    icon: "◫",
+    name: "Live Preview",
+    desc: "See your resume rendered in real time as you make edits.",
+  },
+  {
+    icon: "▤",
+    name: "3 Templates",
+    desc: "Modern, Minimal, and Compact ATS — pick what fits your industry.",
+  },
+  {
+    icon: "✓",
+    name: "ATS-Safe Export",
+    desc: "Machine-readable PDFs with no images or tables to confuse parsers.",
+  },
+  {
+    icon: "◇",
+    name: "Draft Storage",
+    desc: "Auto-saved to your browser's IndexedDB — no cloud needed.",
+  },
+];
+---
+
+<Layout
+  title="Tailory — Modern Resume Editor"
+  description="A fully client-side resume editor. No server, no account."
+>
+  <Fragment slot="head">
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,300;0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700;1,9..40,400&family=DM+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+  </Fragment>
+
+  <div
+    class="min-h-screen bg-white text-gray-900"
+    style="font-family: 'DM Sans', system-ui, sans-serif;"
+  >
+    <!-- Nav -->
+    <header class="sticky top-0 z-50 border-b border-gray-100 bg-white/95 backdrop-blur">
+      <nav class="mx-auto flex max-w-6xl items-center justify-between px-6 py-4">
+        <span class="text-lg font-semibold tracking-tight text-gray-900">Tailory</span>
+        <div class="flex items-center gap-6">
+          <a
+            href="/features"
+            class="hidden text-sm text-gray-500 transition-colors hover:text-gray-900 sm:block"
+            >Features</a
+          >
+          <a
+            href="https://github.com/abijith-suresh/tailory"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="text-sm text-gray-600 transition-colors hover:text-gray-900"
+          >
+            GitHub
+          </a>
+          <a
+            href="/editor"
+            class="rounded-full bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700"
+          >
+            Get Started
+          </a>
+        </div>
+      </nav>
+    </header>
+
+    <!-- Hero -->
+    <section class="mx-auto max-w-6xl px-6 pb-20 pt-24 text-center">
+      <div
+        class="mb-8 inline-flex items-center gap-2 rounded-full bg-blue-50 px-4 py-1.5 text-xs font-medium text-blue-700"
+        style="font-family: 'DM Mono', monospace;"
+      >
+        100% client-side · No account required
+      </div>
+      <h1
+        class="mx-auto mb-6 max-w-3xl text-5xl font-bold leading-tight tracking-tight text-gray-900 sm:text-6xl"
+      >
+        Build a better resume,<br />
+        <span class="text-blue-600">right in your browser.</span>
+      </h1>
+      <p class="mx-auto mb-10 max-w-xl text-xl font-normal leading-relaxed text-gray-500">
+        Upload your existing resume, edit it in a structured form, and export an ATS-optimized PDF —
+        no server, no account, no data leaves your device.
+      </p>
+      <div class="flex flex-col justify-center gap-3 sm:flex-row">
+        <a
+          href="/editor"
+          class="inline-flex items-center justify-center gap-2 rounded-xl bg-blue-600 px-8 py-3.5 text-base font-semibold text-white shadow-lg shadow-blue-200 transition-colors hover:bg-blue-700"
+        >
+          Get Started →
+        </a>
+        <a
+          href="/features"
+          class="inline-flex items-center justify-center gap-2 rounded-xl border border-gray-200 bg-gray-50 px-8 py-3.5 text-base font-medium text-gray-700 transition-colors hover:bg-gray-100"
+        >
+          See Features
+        </a>
+      </div>
+    </section>
+
+    <!-- Features -->
+    <section class="bg-gray-50 py-24">
+      <div class="mx-auto max-w-6xl px-6">
+        <div class="mb-16 text-center">
+          <h2 class="mb-3 text-3xl font-bold text-gray-900">Everything you need</h2>
+          <p class="mx-auto max-w-md text-gray-500">
+            A complete resume editing toolkit, built for the browser.
+          </p>
+        </div>
+        <div class="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+          {
+            features.map((f) => (
+              <div class="rounded-2xl border border-gray-100 bg-white p-7 shadow-sm transition-shadow hover:shadow-md">
+                <div class="mb-5 flex h-10 w-10 items-center justify-center rounded-xl bg-blue-50 text-lg text-blue-600">
+                  {f.icon}
+                </div>
+                <h3 class="mb-2 text-base font-semibold text-gray-900">{f.name}</h3>
+                <p class="text-sm leading-relaxed text-gray-500">{f.desc}</p>
+              </div>
+            ))
+          }
+        </div>
+      </div>
+    </section>
+
+    <!-- How it works -->
+    <section class="py-24">
+      <div class="mx-auto max-w-6xl px-6">
+        <div class="mb-16 text-center">
+          <h2 class="mb-3 text-3xl font-bold text-gray-900">How it works</h2>
+          <p class="text-gray-500">Three steps from upload to export.</p>
+        </div>
+        <div class="mx-auto grid max-w-4xl grid-cols-1 gap-8 md:grid-cols-3">
+          {
+            [
+              {
+                n: 1,
+                title: "Upload your resume",
+                desc: "Drop a PDF or DOCX file — or start fresh from a blank form.",
+              },
+              {
+                n: 2,
+                title: "Edit every detail",
+                desc: "Update fields in a clean structured form with live preview on the side.",
+              },
+              {
+                n: 3,
+                title: "Export your PDF",
+                desc: "Download an ATS-optimized PDF, ready to submit anywhere.",
+              },
+            ].map((s) => (
+              <div class="text-center">
+                <div class="mx-auto mb-5 flex h-12 w-12 items-center justify-center rounded-full bg-blue-600 text-lg font-bold text-white">
+                  {s.n}
+                </div>
+                <h3 class="mb-2 text-lg font-semibold text-gray-900">{s.title}</h3>
+                <p class="text-sm leading-relaxed text-gray-500">{s.desc}</p>
+              </div>
+            ))
+          }
+        </div>
+      </div>
+    </section>
+
+    <!-- Privacy callout -->
+    <section class="bg-blue-600 py-20">
+      <div class="mx-auto max-w-4xl px-6 text-center">
+        <h2 class="mb-4 text-3xl font-bold text-white">Zero data collection. Guaranteed.</h2>
+        <p class="mx-auto max-w-md text-lg leading-relaxed text-blue-100">
+          No telemetry, no cloud sync, no accounts. Everything happens locally — your resume data
+          never touches a server.
+        </p>
+      </div>
+    </section>
+
+    <!-- Footer -->
+    <footer class="border-t border-gray-100 py-10">
+      <div
+        class="mx-auto flex max-w-6xl flex-col items-center justify-between gap-4 px-6 sm:flex-row"
+      >
+        <p class="text-sm text-gray-400">© 2025 Tailory</p>
+        <nav class="flex gap-6 text-sm text-gray-500">
+          <a href="/features" class="transition-colors hover:text-gray-900">Features</a>
+          <a href="/about" class="transition-colors hover:text-gray-900">About</a>
+          <a href="/faq" class="transition-colors hover:text-gray-900">FAQ</a>
+        </nav>
+      </div>
+    </footer>
+  </div>
+</Layout>

--- a/src/pages/3.astro
+++ b/src/pages/3.astro
@@ -1,0 +1,181 @@
+---
+import Layout from "@/layouts/Layout.astro";
+
+const features = [
+  { name: "PDF & DOCX Upload", desc: "Any resume format, dropped in." },
+  { name: "Auto-Parsing", desc: "Structured JSON from raw text, instantly." },
+  { name: "Live Preview", desc: "Real-time rendering as you type." },
+  { name: "3 Templates", desc: "Modern, Minimal, Compact ATS." },
+  { name: "ATS-Safe Export", desc: "Clean PDFs that pass every scanner." },
+  { name: "Draft Storage", desc: "Auto-saved to your browser, locally." },
+];
+---
+
+<Layout
+  title="Tailory — Resume Editor"
+  description="A fully client-side resume editor. No server, no account."
+>
+  <Fragment slot="head">
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Syne:wght@400;500;600;700;800&family=Instrument+Sans:ital,wght@0,400;0,500;0,600;1,400&display=swap"
+      rel="stylesheet"
+    />
+  </Fragment>
+
+  <div
+    class="min-h-screen overflow-x-hidden bg-[#09080f] text-white"
+    style="font-family: 'Instrument Sans', system-ui, sans-serif;"
+  >
+    <!-- Nav -->
+    <header class="relative z-50 mx-auto flex max-w-7xl items-center justify-between px-8 py-6">
+      <span
+        class="text-xl font-bold tracking-tight text-white"
+        style="font-family: 'Syne', sans-serif;"
+      >
+        Tailory
+      </span>
+      <a
+        href="https://github.com/abijith-suresh/tailory"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="rounded-full border border-white/10 px-4 py-2 text-sm text-white/50 transition-colors hover:text-white"
+      >
+        GitHub
+      </a>
+    </header>
+
+    <!-- Hero -->
+    <section class="relative mx-auto max-w-7xl overflow-hidden px-8 pb-32 pt-16">
+      <!-- Background gradient blobs -->
+      <div
+        class="pointer-events-none absolute -left-32 -top-32 h-[600px] w-[600px] rounded-full opacity-30 blur-3xl"
+        style="background: radial-gradient(circle, #6d28d9, #4f46e5, transparent 70%);"
+      >
+      </div>
+      <div
+        class="pointer-events-none absolute right-0 top-0 h-[400px] w-[400px] rounded-full opacity-20 blur-3xl"
+        style="background: radial-gradient(circle, #7c3aed, transparent 70%);"
+      >
+      </div>
+
+      <div class="relative">
+        <div
+          class="mb-8 inline-block rounded-full border border-violet-500/30 bg-violet-500/10 px-4 py-1.5 text-xs uppercase tracking-widest text-violet-300"
+        >
+          No server. No account. Just your browser.
+        </div>
+        <h1
+          class="mb-8 max-w-4xl text-7xl font-extrabold sm:text-8xl"
+          style="font-family: 'Syne', sans-serif; line-height: 1.0;"
+        >
+          Resume editing,<br />
+          <span
+            style="background: linear-gradient(135deg, #a78bfa, #818cf8, #c4b5fd); -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text;"
+          >
+            reimagined.
+          </span>
+        </h1>
+        <p class="mb-10 max-w-lg text-xl leading-relaxed text-white/60">
+          Upload a PDF or DOCX. Edit in a structured form. Export an ATS-safe PDF. Everything
+          happens in your browser — zero data leaves your device.
+        </p>
+        <a
+          href="/editor"
+          class="inline-flex items-center gap-2 rounded-full px-8 py-4 text-base font-semibold text-white transition-all hover:scale-105"
+          style="background: linear-gradient(135deg, #6d28d9, #4f46e5); box-shadow: 0 0 40px rgba(109,40,217,0.5);"
+        >
+          Get Started →
+        </a>
+      </div>
+    </section>
+
+    <!-- Features -->
+    <section class="relative border-t border-white/5 py-24">
+      <div class="mx-auto max-w-7xl px-8">
+        <h2 class="mb-16 text-center text-4xl font-bold" style="font-family: 'Syne', sans-serif;">
+          What it <span class="text-violet-400">does</span>
+        </h2>
+        <div
+          class="grid grid-cols-1 border border-white/5 bg-white/5 sm:grid-cols-2 lg:grid-cols-3"
+        >
+          {
+            features.map((f) => (
+              <div class="bg-[#09080f] p-8 transition-colors hover:bg-white/5">
+                <h3 class="mb-2 text-base font-semibold text-white">{f.name}</h3>
+                <p class="text-sm text-white/40">{f.desc}</p>
+              </div>
+            ))
+          }
+        </div>
+      </div>
+    </section>
+
+    <!-- How it works -->
+    <section class="py-24">
+      <div class="mx-auto max-w-7xl px-8">
+        <h2 class="mb-16 text-center text-4xl font-bold" style="font-family: 'Syne', sans-serif;">
+          Three steps
+        </h2>
+        <div class="grid grid-cols-1 gap-8 md:grid-cols-3">
+          {
+            [
+              { n: "1", title: "Upload", desc: "Drop your PDF or DOCX — or start blank." },
+              {
+                n: "2",
+                title: "Edit",
+                desc: "Structured fields, live preview, no formatting fights.",
+              },
+              { n: "3", title: "Export", desc: "ATS-safe PDF in one click." },
+            ].map((s) => (
+              <div class="rounded-2xl border border-white/10 p-8 transition-colors hover:border-violet-500/40">
+                <p
+                  class="mb-6 text-6xl font-extrabold text-violet-500/20"
+                  style="font-family: 'Syne', sans-serif;"
+                >
+                  {s.n}
+                </p>
+                <h3 class="mb-2 text-xl font-semibold text-white">{s.title}</h3>
+                <p class="text-sm leading-relaxed text-white/50">{s.desc}</p>
+              </div>
+            ))
+          }
+        </div>
+      </div>
+    </section>
+
+    <!-- Privacy callout -->
+    <section class="relative overflow-hidden py-24">
+      <div
+        class="absolute inset-0 opacity-10"
+        style="background: radial-gradient(ellipse at center, #6d28d9, transparent 70%);"
+      >
+      </div>
+      <div class="relative mx-auto max-w-3xl px-8 text-center">
+        <h2 class="mb-6 text-5xl font-extrabold" style="font-family: 'Syne', sans-serif;">
+          Your data stays<br />
+          <span class="text-violet-400">with you.</span>
+        </h2>
+        <p class="text-lg leading-relaxed text-white/50">
+          No telemetry. No accounts. No cloud. Tailory is a browser-only tool — everything runs
+          locally, nothing is ever sent anywhere.
+        </p>
+      </div>
+    </section>
+
+    <!-- Footer -->
+    <footer class="border-t border-white/5 py-10">
+      <div
+        class="mx-auto flex max-w-7xl flex-col items-center justify-between gap-4 px-8 sm:flex-row"
+      >
+        <p class="text-sm text-white/20">© 2025 Tailory</p>
+        <nav class="flex gap-6 text-sm text-white/40">
+          <a href="/features" class="transition-colors hover:text-white">Features</a>
+          <a href="/about" class="transition-colors hover:text-white">About</a>
+          <a href="/faq" class="transition-colors hover:text-white">FAQ</a>
+        </nav>
+      </div>
+    </footer>
+  </div>
+</Layout>

--- a/src/pages/4.astro
+++ b/src/pages/4.astro
@@ -1,0 +1,226 @@
+---
+import Layout from "@/layouts/Layout.astro";
+
+const features = [
+  {
+    name: "PDF & DOCX Upload",
+    desc: "Text extraction from both formats via pdfjs-dist and mammoth.",
+  },
+  { name: "Auto-Parsing", desc: "Section detection and field mapping — no manual copy-paste." },
+  { name: "Live Preview", desc: "Immediate visual feedback. What you edit is what you get." },
+  {
+    name: "3 Templates",
+    desc: "Modern. Minimal. Compact ATS. All text-only, all machine-readable.",
+  },
+  {
+    name: "ATS-Safe Export",
+    desc: "pdfmake generates strictly compliant PDFs — no images, no tables.",
+  },
+  {
+    name: "Draft Storage",
+    desc: "IndexedDB auto-save. Persists across sessions, stays local.",
+  },
+];
+---
+
+<Layout title="Tailory" description="A fully client-side resume editor.">
+  <Fragment slot="head">
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital,wght@0,400;0,500;0,600;0,700;1,400&family=IBM+Plex+Sans:ital,wght@0,300;0,400;0,500;1,400&display=swap"
+      rel="stylesheet"
+    />
+  </Fragment>
+
+  <div
+    class="min-h-screen bg-[#f4f4f0] text-[#0f0f0f]"
+    style="font-family: 'IBM Plex Sans', system-ui, sans-serif;"
+  >
+    <!-- Nav -->
+    <header class="border-b-2 border-[#0f0f0f]">
+      <nav class="mx-auto flex max-w-7xl items-center justify-between px-6 py-4">
+        <span
+          class="text-base font-bold tracking-tight text-[#0f0f0f]"
+          style="font-family: 'IBM Plex Mono', monospace;"
+        >
+          TAILORY
+        </span>
+        <div class="flex items-center">
+          <a
+            href="https://github.com/abijith-suresh/tailory"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="border-l-2 border-[#0f0f0f] px-4 py-2 text-xs text-[#0f0f0f] transition-colors hover:bg-[#0f0f0f] hover:text-[#f4f4f0]"
+            style="font-family: 'IBM Plex Mono', monospace;"
+          >
+            GITHUB ↗
+          </a>
+          <a
+            href="/editor"
+            class="border-l-2 border-[#0f0f0f] bg-[#0f0f0f] px-4 py-2 text-xs text-[#f4f4f0] transition-colors hover:bg-[#333]"
+            style="font-family: 'IBM Plex Mono', monospace;"
+          >
+            OPEN EDITOR →
+          </a>
+        </div>
+      </nav>
+    </header>
+
+    <!-- Hero -->
+    <section class="mx-auto max-w-7xl border-b-2 border-[#0f0f0f] px-6 py-20">
+      <div class="grid grid-cols-1 items-end gap-12 md:grid-cols-2">
+        <div>
+          <p
+            class="mb-6 text-xs uppercase tracking-widest text-[#666]"
+            style="font-family: 'IBM Plex Mono', monospace;"
+          >
+            v0.1.0 — Client-side only
+          </p>
+          <h1
+            class="mb-8 text-5xl font-bold text-[#0f0f0f]"
+            style="font-family: 'IBM Plex Mono', monospace; line-height: 1.1;"
+          >
+            Resume editor.<br />
+            No server.<br />
+            No nonsense.
+          </h1>
+          <a
+            href="/editor"
+            class="inline-block bg-[#0f0f0f] px-6 py-3 text-sm font-medium text-[#f4f4f0] transition-colors hover:bg-[#333]"
+            style="font-family: 'IBM Plex Mono', monospace;"
+          >
+            GET STARTED →
+          </a>
+        </div>
+        <div class="border-2 border-[#0f0f0f] p-8">
+          <p
+            class="mb-4 text-xs uppercase tracking-widest text-[#666]"
+            style="font-family: 'IBM Plex Mono', monospace;"
+          >
+            What it is
+          </p>
+          <p class="text-base leading-relaxed text-[#333]">
+            Upload a PDF or DOCX resume. Tailory parses it into structured fields. Edit in a clean
+            form. Preview in real time. Export an ATS-compatible PDF. Zero network requests. Zero
+            accounts. Your data, your browser, full stop.
+          </p>
+        </div>
+      </div>
+    </section>
+
+    <!-- Features -->
+    <section class="mx-auto max-w-7xl border-b-2 border-[#0f0f0f] px-6 py-20">
+      <p
+        class="mb-12 text-xs uppercase tracking-widest text-[#666]"
+        style="font-family: 'IBM Plex Mono', monospace;"
+      >
+        Capabilities
+      </p>
+      <div class="grid grid-cols-1 border-t-2 border-[#0f0f0f] sm:grid-cols-2 lg:grid-cols-3">
+        {
+          features.map((f) => (
+            <div class="border-b-2 border-r-0 border-[#0f0f0f] py-8 pr-8 last:border-b-0 sm:border-r-2 lg:border-b-0">
+              <h3
+                class="mb-3 text-sm font-semibold text-[#0f0f0f]"
+                style="font-family: 'IBM Plex Mono', monospace;"
+              >
+                {f.name}
+              </h3>
+              <p class="text-sm font-light leading-relaxed text-[#555]">{f.desc}</p>
+            </div>
+          ))
+        }
+      </div>
+    </section>
+
+    <!-- How it works -->
+    <section class="mx-auto max-w-7xl border-b-2 border-[#0f0f0f] px-6 py-20">
+      <p
+        class="mb-12 text-xs uppercase tracking-widest text-[#666]"
+        style="font-family: 'IBM Plex Mono', monospace;"
+      >
+        Process
+      </p>
+      <div class="grid grid-cols-1 md:grid-cols-3">
+        {
+          [
+            { n: "01", title: "Upload", desc: "Drop a PDF or DOCX. Or start from scratch." },
+            {
+              n: "02",
+              title: "Edit",
+              desc: "Structured fields. Live preview. No formatting fights.",
+            },
+            { n: "03", title: "Export", desc: "ATS-safe PDF. Download. Done." },
+          ].map((s, i) => (
+            <div
+              class:list={`py-10 pr-12 ${i < 2 ? "border-b-2 border-[#0f0f0f] md:border-b-0 md:border-r-2" : ""}`}
+            >
+              <p
+                class="mb-8 text-6xl font-bold text-[#ddd]"
+                style="font-family: 'IBM Plex Mono', monospace;"
+              >
+                {s.n}
+              </p>
+              <h3
+                class="mb-3 text-lg font-semibold text-[#0f0f0f]"
+                style="font-family: 'IBM Plex Mono', monospace;"
+              >
+                {s.title}
+              </h3>
+              <p class="text-sm font-light leading-relaxed text-[#555]">{s.desc}</p>
+            </div>
+          ))
+        }
+      </div>
+    </section>
+
+    <!-- Privacy callout -->
+    <section class="bg-[#0f0f0f] text-[#f4f4f0]">
+      <div class="mx-auto max-w-7xl px-6 py-20">
+        <h2
+          class="mb-6 max-w-2xl text-4xl font-bold"
+          style="font-family: 'IBM Plex Mono', monospace; line-height: 1.1;"
+        >
+          ZERO DATA COLLECTION.<br />
+          ZERO EXCEPTIONS.
+        </h2>
+        <p class="max-w-lg text-base font-light leading-relaxed text-[#888]">
+          Tailory is a static web app. There is no server receiving your data, no analytics tracking
+          your session, no account to create. Your resume lives in your browser and nowhere else.
+        </p>
+      </div>
+    </section>
+
+    <!-- Footer -->
+    <footer class="border-t-2 border-[#0f0f0f]">
+      <div
+        class="mx-auto flex max-w-7xl flex-col items-center justify-between gap-4 px-6 py-8 sm:flex-row"
+      >
+        <p class="text-xs text-[#999]" style="font-family: 'IBM Plex Mono', monospace;">
+          © 2025 TAILORY — MIT LICENSE
+        </p>
+        <nav class="flex text-xs" style="font-family: 'IBM Plex Mono', monospace;">
+          <a
+            href="/features"
+            class="border-l-2 border-[#ddd] px-4 py-2 text-[#0f0f0f] transition-colors hover:bg-[#0f0f0f] hover:text-[#f4f4f0]"
+          >
+            FEATURES
+          </a>
+          <a
+            href="/about"
+            class="border-l-2 border-[#ddd] px-4 py-2 text-[#0f0f0f] transition-colors hover:bg-[#0f0f0f] hover:text-[#f4f4f0]"
+          >
+            ABOUT
+          </a>
+          <a
+            href="/faq"
+            class="border-l-2 border-[#ddd] px-4 py-2 text-[#0f0f0f] transition-colors hover:bg-[#0f0f0f] hover:text-[#f4f4f0]"
+          >
+            FAQ
+          </a>
+        </nav>
+      </div>
+    </footer>
+  </div>
+</Layout>

--- a/src/pages/5.astro
+++ b/src/pages/5.astro
@@ -1,0 +1,213 @@
+---
+import Layout from "@/layouts/Layout.astro";
+
+const features = [
+  {
+    icon: "⬆",
+    name: "PDF & DOCX Upload",
+    desc: "Drop your resume in any common format — Tailory reads it for you.",
+  },
+  {
+    icon: "✦",
+    name: "Auto-Parsing",
+    desc: "Smart section detection fills in your fields automatically.",
+  },
+  {
+    icon: "◎",
+    name: "Live Preview",
+    desc: "Watch your resume update as you type — no refresh needed.",
+  },
+  {
+    icon: "▣",
+    name: "Three Templates",
+    desc: "Modern, Minimal, and Compact ATS — all clean, all ATS-friendly.",
+  },
+  {
+    icon: "✓",
+    name: "ATS-Safe Export",
+    desc: "Download a machine-readable PDF that gets past every scanner.",
+  },
+  {
+    icon: "◈",
+    name: "Draft Storage",
+    desc: "Your work saves automatically in your browser. No cloud needed.",
+  },
+];
+---
+
+<Layout
+  title="Tailory — Resume Editor"
+  description="A fully client-side resume editor. No server, no account."
+>
+  <Fragment slot="head">
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Lora:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&family=Mulish:ital,wght@0,300;0,400;0,500;0,600;1,400&display=swap"
+      rel="stylesheet"
+    />
+  </Fragment>
+
+  <div
+    class="min-h-screen text-[#2c2416]"
+    style="font-family: 'Mulish', system-ui, sans-serif; background: #faf6f0;"
+  >
+    <!-- Nav -->
+    <header class="mx-auto max-w-5xl px-6 pt-6">
+      <nav class="flex items-center justify-between border-b border-[#e8ddd0] py-4">
+        <span
+          class="text-xl font-semibold tracking-tight text-[#2c2416]"
+          style="font-family: 'Lora', Georgia, serif;"
+        >
+          Tailory
+        </span>
+        <a
+          href="https://github.com/abijith-suresh/tailory"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="text-sm text-[#9a8a72] transition-colors hover:text-[#2c2416]"
+        >
+          GitHub ↗
+        </a>
+      </nav>
+    </header>
+
+    <!-- Hero -->
+    <section class="mx-auto max-w-5xl px-6 py-24">
+      <div class="max-w-2xl">
+        <p class="mb-6 text-sm font-medium tracking-wide text-[#c47c30]">
+          Free · Open source · No account required
+        </p>
+        <h1
+          class="mb-6 text-5xl font-bold text-[#2c2416]"
+          style="font-family: 'Lora', Georgia, serif; line-height: 1.2;"
+        >
+          A resume editor that<br />
+          <em class="text-[#c47c30]">stays in your browser.</em>
+        </h1>
+        <p class="mb-10 text-lg leading-relaxed text-[#7a6a52]">
+          Upload a PDF or DOCX, edit in a structured form, preview live, and export a clean ATS-safe
+          PDF. Your data never leaves your device.
+        </p>
+        <div class="flex items-center gap-4">
+          <a
+            href="/editor"
+            class="inline-block rounded-full bg-[#c47c30] px-7 py-3.5 text-sm font-semibold text-white transition-colors hover:bg-[#b06a22]"
+          >
+            Get Started →
+          </a>
+          <a href="/features" class="text-sm text-[#9a8a72] transition-colors hover:text-[#2c2416]">
+            Learn more ↓
+          </a>
+        </div>
+      </div>
+    </section>
+
+    <!-- Features -->
+    <section class="py-24" style="background: #f2ece3;">
+      <div class="mx-auto max-w-5xl px-6">
+        <h2
+          class="mb-3 text-3xl font-semibold text-[#2c2416]"
+          style="font-family: 'Lora', Georgia, serif;"
+        >
+          What Tailory does
+        </h2>
+        <p class="mb-14 text-base text-[#9a8a72]">No fluff — just the features that matter.</p>
+        <div class="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3">
+          {
+            features.map((f) => (
+              <div class="rounded-2xl border border-[#e8ddd0] p-6" style="background: #faf6f0;">
+                <span class="mb-4 block text-xl text-[#c47c30]">{f.icon}</span>
+                <h3
+                  class="mb-2 text-base font-semibold text-[#2c2416]"
+                  style="font-family: 'Lora', Georgia, serif;"
+                >
+                  {f.name}
+                </h3>
+                <p class="text-sm leading-relaxed text-[#7a6a52]">{f.desc}</p>
+              </div>
+            ))
+          }
+        </div>
+      </div>
+    </section>
+
+    <!-- How it works -->
+    <section class="mx-auto max-w-5xl px-6 py-24">
+      <h2
+        class="mb-14 text-3xl font-semibold text-[#2c2416]"
+        style="font-family: 'Lora', Georgia, serif;"
+      >
+        How it works
+      </h2>
+      <div class="grid grid-cols-1 gap-10 md:grid-cols-3">
+        {
+          [
+            {
+              n: "1",
+              title: "Upload your resume",
+              desc: "Drop in your existing PDF or DOCX — or start from a blank slate.",
+            },
+            {
+              n: "2",
+              title: "Edit every detail",
+              desc: "Clean, structured fields with live preview. No wrestling with formatting.",
+            },
+            {
+              n: "3",
+              title: "Export your PDF",
+              desc: "One click to download an ATS-ready PDF. Clean, readable, ready to send.",
+            },
+          ].map((s) => (
+            <div class="flex gap-5">
+              <span
+                class="w-8 flex-shrink-0 text-3xl font-bold text-[#e8ddd0]"
+                style="font-family: 'Lora', Georgia, serif;"
+              >
+                {s.n}
+              </span>
+              <div>
+                <h3
+                  class="mb-2 text-lg font-semibold text-[#2c2416]"
+                  style="font-family: 'Lora', Georgia, serif;"
+                >
+                  {s.title}
+                </h3>
+                <p class="text-sm leading-relaxed text-[#7a6a52]">{s.desc}</p>
+              </div>
+            </div>
+          ))
+        }
+      </div>
+    </section>
+
+    <!-- Privacy callout -->
+    <section class="border-b border-t border-[#e8ddd0] py-20" style="background: #fdf8f4;">
+      <div class="mx-auto max-w-5xl px-6 text-center">
+        <p class="mb-4 text-xs font-medium uppercase tracking-wide text-[#c47c30]">Privacy first</p>
+        <h2
+          class="mb-4 text-3xl font-semibold text-[#2c2416]"
+          style="font-family: 'Lora', Georgia, serif;"
+        >
+          Your resume is yours alone.
+        </h2>
+        <p class="mx-auto max-w-md text-base leading-relaxed text-[#7a6a52]">
+          Tailory is entirely client-side. There's no server, no tracking, no account to create.
+          Everything — parsing, editing, export — happens locally in your browser.
+        </p>
+      </div>
+    </section>
+
+    <!-- Footer -->
+    <footer
+      class="mx-auto flex max-w-5xl flex-col items-center justify-between gap-4 px-6 py-10 sm:flex-row"
+    >
+      <p class="text-sm text-[#c4b4a0]">© 2025 Tailory</p>
+      <nav class="flex gap-6 text-sm text-[#9a8a72]">
+        <a href="/features" class="transition-colors hover:text-[#2c2416]">Features</a>
+        <a href="/about" class="transition-colors hover:text-[#2c2416]">About</a>
+        <a href="/faq" class="transition-colors hover:text-[#2c2416]">FAQ</a>
+      </nav>
+    </footer>
+  </div>
+</Layout>


### PR DESCRIPTION
## Summary
Five fully distinct landing page designs for Tailory — each a complete Astro page with nav, hero, features, how it works, privacy callout, and footer.

## Designs

| Route | Direction | Description |
|-------|-----------|-------------|
| `/1` | **Dark Editorial** | Near-black `#0a0a0f` bg, Georgia serif headline, pale indigo accent `#9ea6d4`, minimal decoration, copy-focused |
| `/2` | **Light & Clean** | White bg, DM Sans, blue accent, card grid with soft shadows, professional SaaS feel |
| `/3` | **Gradient Bold** | Deep `#09080f` bg, Syne display font, vivid indigo-violet gradient blobs, energetic hero |
| `/4` | **Monochrome Precision** | Off-white `#f4f4f0` bg, IBM Plex Mono/Sans, strict 2px black borders, brutalist-lite grid |
| `/5` | **Warm Minimal** | Cream `#faf6f0` bg, Lora serif + Mulish, amber `#c47c30` accent, approachable indie feel |

## Test plan
- [ ] Run `bun dev` and visit `/1`, `/2`, `/3`, `/4`, `/5` to review each design
- [ ] All CTAs link to `/editor`
- [ ] Responsive on mobile
- [ ] Pick a design — then we'll replace `index.astro` and build out all marketing pages in a follow-up PR