### PR TITLE
chore: setup release-please baseline at v0.6.1

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,8 +13,9 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/release-please-action@v4
+      - uses: googleapis/release-please-action@v4
+        id: release
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json

--- a/.prettierignore
+++ b/.prettierignore
@@ -3,3 +3,4 @@ dist/
 node_modules/
 bun.lock
 bun.lockb
+CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+<!-- Entries below this line were manually maintained prior to automated release management -->
+
 # Changelog
 
 All notable changes to this project will be documented in this file.

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,10 +1,11 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "release-type": "node",
   "packages": {
-    ".": {
-      "release-type": "node",
-      "package-name": "tailory",
-      "include-v-in-tag": true
-    }
-  }
+    ".": {}
+  },
+  "bump-minor-pre-major": true,
+  "bump-patch-for-minor-pre-major": true,
+  "include-component-in-tag": false,
+  "bootstrap-sha": "a0838d947bac100ab4e13f8e354d2680b46920a2"
 }


### PR DESCRIPTION
Sets up a clean Release Please configuration from scratch.

## Changes
- Fixes workflow to use current `googleapis/release-please-action@v4` (replaces archived action)
- Switches token from `GITHUB_TOKEN` to `RELEASE_PLEASE_TOKEN` to allow triggered workflows
- Corrects `release-please-config.json` with pre-1.0 versioning settings, correct tag format, and bootstrap SHA anchor
- Sets `.release-please-manifest.json` to the agreed baseline version
- Aligns `package.json` version with the baseline
- Adds handover comment to `CHANGELOG.md` marking where automated entries will begin
- Adds `CHANGELOG.md` to `.prettierignore` to prevent CI failures on autogenerated release changelogs

## Baseline version
`v0.6.1` — all commits merged to main after this point will be tracked by Release Please.