### PR TITLE
ci: add node setup for Astro compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 24
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:


### PR DESCRIPTION
## Summary

Add `actions/setup-node@v5` with `node-version: 24` to the CI workflow for Astro/tooling runtime compatibility.

## What changed

- Added `actions/setup-node@v5` step with `node-version: 24` to `.github/workflows/ci.yml`
- Node setup is placed **before** Bun setup

## What did NOT change

- **Bun remains the package manager** — `bun install --frozen-lockfile` is unchanged
- **Bun remains the script runner** — `bun run verify` is unchanged
- **Bun versioning** — `bun-version-file: ".bun-version"` and cache settings preserved
- **All existing checks** — dependency review, quality gate, permissions unchanged
- No modifications to `package.json`, `Dependabot config`, release workflows, or docs

## Checklist

- [x] Only `.github/workflows/ci.yml` was modified
- [x] Node 24 setup added before Bun setup
- [x] Bun remains package manager, lockfile manager, and script runner
- [x] All existing CI steps preserved
- [x] Local `bun run verify` passed (type-check, lint, format, tests, build)