### PR TITLE
docs: correct product claims and license metadata

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Tailory contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,38 +1,68 @@
 # Tailory
 
-**A fully client-side resume editor.** Upload a PDF or DOCX, edit your resume in a structured form, preview it live, and export an ATS-compatible PDF — all in the browser. No server, no accounts, no data leaves your device.
+**A fully client-side resume editor.** Import a PDF, DOCX, or JSON Resume file, edit structured resume data, preview it live, and export an ATS-friendly PDF or JSON document — all in the browser.
 
-## Features
+## What Tailory does today
 
-- **Upload & Parse** — Drop a PDF or DOCX resume; Tailory extracts and structures your data automatically
-- **Edit** — Full form editor for all resume sections (basics, work, education, skills, projects, certs)
-- **Live Preview** — See a visual preview update in real time as you type
-- **3 Templates** — Modern, Minimal, and Compact ATS layouts
-- **Export** — Download a clean, ATS-safe PDF with one click
-- **Draft Storage** — Auto-saves to IndexedDB; your work persists across sessions
+- **Client-side import** — Open PDF, DOCX, and `.json` resume files locally in your browser
+- **Structured editing** — Edit core sections in forms: basics, summary, work, education, skills, projects, and certifications
+- **Live preview** — See the current resume render update as you edit
+- **Three templates** — Modern, Minimal, and Compact ATS
+- **Export** — Download a PDF or export the current resume as JSON
+- **Local drafts** — Autosave and named drafts are stored in IndexedDB on your device
+
+## Current limits
+
+- Some schema-backed sections already render in preview/export and survive JSON round-trips, but are **not yet editable in the form UI**
+- JSON Resume support is implemented through Tailory's normalization layer; it is **not yet formally validated against the official schema package**
+- Tailory is browser-only and privacy-first, but it is **not an offline-first PWA** — there is no service worker, so the first load still depends on normal browser/network behavior
+- The preview is designed to stay close to export output, but the exported PDF remains the final source of truth
+
+## JSON Resume support
+
+Tailory can import and export JSON Resume-style documents for the fields it currently supports. In practice:
+
+- supported fields are normalized on import and exported back as clean JSON
+- internal entry IDs are removed during export
+- unsupported or non-standard shapes may be rejected or normalized away
+- some fields Tailory can preserve or render are still not exposed in the editor UI
+
+## Privacy and storage
+
+Tailory has no application backend, no accounts, and no server-side resume processing. Your resume data stays in your browser unless **you** choose to export or share it.
+
+Drafts and autosaves are stored in IndexedDB. Clearing site data in your browser will remove them.
 
 ## Stack
 
-- [Astro 5](https://astro.build) — static site framework
-- [SolidJS](https://solidjs.com) — reactive UI islands
-- [Tailwind CSS v4](https://tailwindcss.com) — utility-first CSS
-- [TypeScript](https://www.typescriptlang.org) — strict mode
-- [Bun](https://bun.sh) — package manager and runtime
-- [PDF.js](https://mozilla.github.io/pdf.js/) — client-side PDF text extraction
-- [mammoth](https://github.com/mwilliamson/mammoth.js) — DOCX extraction
-- [pdfmake](http://pdfmake.org) — programmatic ATS-safe PDF generation
-- [idb](https://github.com/jakearchibald/idb) — typed IndexedDB wrapper
+- [Astro 6](https://astro.build)
+- [SolidJS](https://solidjs.com)
+- [Tailwind CSS v4](https://tailwindcss.com)
+- [TypeScript](https://www.typescriptlang.org)
+- [Bun](https://bun.sh)
+- [PDF.js](https://mozilla.github.io/pdf.js/)
+- [mammoth](https://github.com/mwilliamson/mammoth.js)
+- [pdfmake](http://pdfmake.org)
+- [idb](https://github.com/jakearchibald/idb)
 
 ## Development
 
 ```sh
-bun install      # install dependencies
-bun dev          # start dev server at localhost:4321
-bun build        # build for production
-bun preview      # preview production build
-bun run test     # run tests
+bun install
+bun run dev
+bun run verify
+```
+
+Useful individual commands:
+
+```sh
+bun run type-check
+bun run lint
+bun run format:check
+bun run test
+bun run build
 ```
 
 ## License
 
-MIT
+MIT — see [LICENSE](./LICENSE).

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "tailory",
   "type": "module",
   "version": "0.6.1",
+  "license": "MIT",
   "packageManager": "bun@1.3.5",
   "scripts": {
     "dev": "astro dev",

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -6,7 +6,7 @@ const techCards = [
     name: "Astro",
     role: "Static site framework",
     detail:
-      "Every marketing page is a zero-JS static HTML file. Only the editor page ships JavaScript — and only as much as the interactive islands need.",
+      "The marketing pages stay mostly static, with small client-side scripts for navigation and reveal effects. The heavier interactive runtime is reserved for the editor experience.",
   },
   {
     name: "SolidJS",
@@ -133,7 +133,7 @@ const techCards = [
           JSON Resume
         </p>
         <p class="text-sm leading-relaxed text-[#3d6650]">
-          Tailory stores resume data using the open{" "}
+          Tailory can import and export{" "}
           <a
             href="https://jsonresume.org"
             target="_blank"
@@ -142,8 +142,9 @@ const techCards = [
           >
             JSON Resume
           </a>{" "}
-          standard schema. This means your data is portable — not locked into a proprietary format. Any
-          tool that speaks JSON Resume can read what Tailory saves.
+          style documents through its normalization layer. Supported fields are portable today, but Tailory
+          does not yet claim full official-schema validation and some schema sections still render better
+          than they edit.
         </p>
       </div>
     </div>

--- a/src/pages/faq.astro
+++ b/src/pages/faq.astro
@@ -12,7 +12,11 @@ const faqs = [
   },
   {
     q: "What file formats can I upload?",
-    a: "Tailory accepts PDF (.pdf) and Word documents (.docx). PDF text is extracted with PDF.js. DOCX text is extracted with Mammoth. Scanned PDFs (image-only) cannot be parsed because there is no text layer to read.",
+    a: "Tailory accepts PDF (.pdf), Word (.docx), and JSON (.json) files. PDF text is extracted with PDF.js, DOCX text is extracted with Mammoth, and JSON imports are normalized as supported JSON Resume-style data. Scanned PDFs (image-only) cannot be parsed because there is no text layer to read.",
+  },
+  {
+    q: "Can I import or export JSON Resume files?",
+    a: "Yes. Tailory can import and export JSON for the fields it currently supports. Supported data is normalized on import and exported without internal IDs, but Tailory does not yet claim full official-schema validation and some schema sections still render better than they edit in the form UI.",
   },
   {
     q: "Which browsers are supported?",
@@ -24,7 +28,7 @@ const faqs = [
   },
   {
     q: "What's the difference between the three templates?",
-    a: "Modern is a two-column layout with accent colour headings, suited for creative and tech roles. Minimal is a clean single-column layout that is widely readable across industries. Compact ATS is a dense single-column format with no decorative elements, maximising compatibility with automated screening tools.",
+    a: "Modern uses a strong two-tone header with clear section dividers. Minimal keeps decoration low and spacing generous. Compact ATS is the densest option and is tuned for plain, keyword-forward output.",
   },
   {
     q: "Where is my data stored between sessions?",
@@ -32,7 +36,7 @@ const faqs = [
   },
   {
     q: "Can I use Tailory offline?",
-    a: "The editor works offline once the page has loaded (fonts and assets are cached by the browser). PDF export and live preview work offline. Uploading a file works offline. The only feature that requires a connection is the initial page load.",
+    a: "Tailory has no server dependency for editing, parsing, previewing, or exporting once the app is loaded, but it is not packaged as an offline-first app and does not ship a service worker. Treat offline use as best-effort browser behavior rather than a guaranteed product feature.",
   },
   {
     q: "Can I start from scratch without uploading a file?",
@@ -47,7 +51,7 @@ const faqs = [
 
 <MarketingLayout
   title="FAQ — Tailory"
-  description="Frequently asked questions about Tailory — privacy, file formats, ATS compatibility, offline use, and more."
+  description="Frequently asked questions about Tailory — privacy, file formats, JSON Resume support, ATS compatibility, and offline limitations."
 >
   <!-- Hero -->
   <section class="mx-auto max-w-6xl px-8 pb-16 pt-24" data-reveal>

--- a/src/pages/features.astro
+++ b/src/pages/features.astro
@@ -4,9 +4,9 @@ import MarketingLayout from "@/layouts/MarketingLayout.astro";
 const features = [
   {
     n: "01",
-    title: "PDF & DOCX Upload",
+    title: "PDF, DOCX & JSON Import",
     detail:
-      "Drag and drop any resume file — PDF or Word document — directly into the editor. Tailory extracts the text entirely in your browser using PDF.js and Mammoth. No file is ever transmitted to a server. Extraction happens instantly, locally, privately.",
+      "Bring in an existing resume as PDF, Word, or JSON. PDF and DOCX text extraction happen entirely in your browser with PDF.js and Mammoth, while JSON imports flow through Tailory's normalization layer for supported fields. No file is sent to an application server.",
     mockup: "upload",
   },
   {
@@ -20,14 +20,14 @@ const features = [
     n: "03",
     title: "Live Preview",
     detail:
-      "The editor and preview panels update in real time as you type. Switch between three templates without leaving the editor. What you see in the preview is exactly what will be exported — no surprises when you download.",
+      "The editor and preview panels update in real time as you type. You can switch between three templates without leaving the editor. The preview stays close to export output, while the generated PDF remains the final source of truth.",
     mockup: "preview",
   },
   {
     n: "04",
     title: "Three Templates",
     detail:
-      "Modern — a two-column layout with accent colour headers, suited for creative and tech roles. Minimal — clean single-column typesetting, widely readable. Compact ATS — dense single-column layout optimised for applicant tracking system parsing, zero decorative elements.",
+      "Modern uses a bold two-tone header with clear section dividers. Minimal keeps things quiet with clean spacing and little decoration. Compact ATS trims the layout down for dense, keyword-forward output.",
     mockup: "templates",
   },
   {
@@ -39,9 +39,9 @@ const features = [
   },
   {
     n: "06",
-    title: "Draft Storage",
+    title: "Local Draft Storage",
     detail:
-      "Tailory autosaves your resume to the browser's IndexedDB after every change. You can also save named drafts to load later. All storage is local — clearing your browser data is the only way to erase it. No cloud, no sync, no account.",
+      "Tailory autosaves your resume to the browser's IndexedDB after every change. You can also save named drafts to load later. Storage stays local to this browser profile — there is no cloud sync, no account, and clearing site data will remove local drafts.",
     mockup: "storage",
   },
 ];
@@ -49,7 +49,7 @@ const features = [
 
 <MarketingLayout
   title="Features — Tailory"
-  description="Everything Tailory does — PDF & DOCX upload, auto-parsing, live preview, three templates, ATS-safe PDF export, and offline draft storage."
+  description="Everything Tailory does today — PDF, DOCX, and JSON import, live preview, three templates, ATS-safe PDF export, and local browser draft storage."
 >
   <!-- Hero -->
   <section class="mx-auto max-w-6xl px-8 pb-16 pt-24" data-reveal>
@@ -95,7 +95,7 @@ const features = [
                 <div class="mx-auto mb-4 flex h-20 w-20 items-center justify-center rounded-2xl border-2 border-dashed border-[#ccddd4]">
                   <span class="text-3xl text-[#a0b8ab]">↑</span>
                 </div>
-                <p class="text-sm font-medium text-[#3d6650]">Drop PDF or DOCX here</p>
+                <p class="text-sm font-medium text-[#3d6650]">Drop PDF, DOCX, or JSON here</p>
                 <p class="mt-1 text-xs text-[#a0b8ab]">or click to browse</p>
                 <div class="mt-4 flex justify-center gap-2">
                   <span class="rounded-full border border-[#ccddd4] px-3 py-1 text-xs text-[#3d6650]">
@@ -103,6 +103,9 @@ const features = [
                   </span>
                   <span class="rounded-full border border-[#ccddd4] px-3 py-1 text-xs text-[#3d6650]">
                     .docx
+                  </span>
+                  <span class="rounded-full border border-[#ccddd4] px-3 py-1 text-xs text-[#3d6650]">
+                    .json
                   </span>
                 </div>
               </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -4,8 +4,8 @@ import MarketingLayout from "@/layouts/MarketingLayout.astro";
 const features = [
   {
     n: "01",
-    term: "PDF & DOCX Upload",
-    def: "Drop any resume format — Tailory handles text extraction entirely in your browser.",
+    term: "PDF, DOCX & JSON Import",
+    def: "Bring in an existing resume as a PDF, DOCX, or JSON document without sending it to an application server.",
   },
   {
     n: "02",
@@ -24,8 +24,8 @@ const features = [
   },
   {
     n: "05",
-    term: "ATS-Safe Export",
-    def: "Machine-readable PDFs with no images or tables to trip up applicant tracking systems.",
+    term: "PDF & JSON Export",
+    def: "Download a machine-readable PDF for applications or export structured JSON for portability.",
   },
   {
     n: "06",
@@ -35,7 +35,10 @@ const features = [
 ];
 
 const steps = [
-  { title: "Upload", desc: "Drop your existing PDF or DOCX resume, or begin from a blank form." },
+  {
+    title: "Upload",
+    desc: "Import an existing PDF, DOCX, or JSON resume, or begin from a blank form.",
+  },
   { title: "Edit", desc: "Refine every field in a calm structured editor. No formatting fights." },
   { title: "Export", desc: "Download a polished, ATS-compatible PDF in one click." },
 ];
@@ -50,7 +53,7 @@ const formFields = [
 
 <MarketingLayout
   title="Tailory — Resume editor that belongs to you"
-  description="A fully client-side resume editor. Upload a PDF or DOCX, edit, preview live, and export an ATS-compatible PDF — all in your browser."
+  description="A fully client-side resume editor. Import PDF, DOCX, or JSON Resume data, edit it locally, preview live, and export PDF or JSON in your browser."
 >
   <!-- Hero -->
   <section class="mx-auto max-w-6xl px-8 pb-20 pt-24" data-reveal>
@@ -65,8 +68,9 @@ const formFields = [
     </h1>
     <div class="mb-10 h-px w-20 bg-[#ccddd4]"></div>
     <p class="mb-10 max-w-xl text-lg leading-relaxed text-[#3d6650]">
-      Upload a PDF or DOCX, edit every field in a calm structured interface, and export an ATS-safe
-      PDF — without sending a single byte to a server.
+      Import a PDF, DOCX, or JSON resume, edit every field in a calm structured interface, and
+      export an ATS-safe PDF or structured JSON — without sending resume data to an application
+      server.
     </p>
     <div class="flex flex-wrap items-center gap-4">
       <a


### PR DESCRIPTION
## Summary
Reconciles Tailory's public-facing copy with the product that ships today and adds the missing MIT license metadata. This removes inaccurate claims around Astro versioning, JSON Resume guarantees, offline support, template descriptions, and marketing-page behavior.

## Changes
- add a real MIT LICENSE file and package license metadata so GitHub can detect the repo license
- update README copy to reflect Astro 6, JSON Resume import/export support, current limits, and browser-only behavior
- correct marketing-page copy around JSON support, preview/export parity, offline guarantees, and template descriptions

## Testing
- [x] bun run verify
- [x] spot-check generated marketing pages via astro build output

## References
- Ticket/Issue: Fixes #50