### PR TITLE
ci: document release source of truth

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ bun run test
 bun run build
 ```
 
+Release workflow notes live in [docs/releases.md](./docs/releases.md).
+
 ## License
 
 MIT — see [LICENSE](./LICENSE).

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,0 +1,48 @@
+# Releases
+
+Tailory uses **Release Please** as the single release manager for version bumps, changelog entries, Git tags, and GitHub releases.
+
+## Source of truth
+
+These files and conventions must stay aligned:
+
+- `package.json` — current published version
+- `.release-please-manifest.json` — Release Please's tracked version for the root package
+- `CHANGELOG.md` — generated release history and compare links
+- Git tags in the format `vX.Y.Z`
+- GitHub Releases created from those tags
+
+If one of these needs to change, update the others in the same pull request.
+
+## Normal release flow
+
+1. Merge conventional-commit PRs into `main`.
+2. The `Release Please` workflow runs on every push to `main`.
+3. If there are user-facing commits since the latest release tag, Release Please opens or updates a PR like `chore(main): release 0.6.2`.
+4. Review that PR's generated version bump and changelog updates.
+5. Merge the release PR into `main`.
+6. On the next workflow run, Release Please creates the `vX.Y.Z` tag and the matching GitHub Release.
+
+## Maintainer rules
+
+- Do **not** hand-edit version numbers in `package.json` for normal releases.
+- Do **not** manually curate new changelog entries below the automated handoff line in `CHANGELOG.md`.
+- Keep Release Please responsible for version, changelog, tag, and GitHub Release naming.
+- Keep tags in the plain `vX.Y.Z` format — no component prefix.
+- Keep the workflow pointed at `release-please-config.json` and `.release-please-manifest.json`.
+
+## Credentials
+
+The workflow uses `RELEASE_PLEASE_TOKEN` so release activity can create or update pull requests and continue the normal GitHub automation flow.
+
+## Baseline and recovery
+
+The current automated baseline is anchored from the bootstrap SHA in `release-please-config.json` and the root version in `.release-please-manifest.json`.
+
+If release history ever needs repair:
+
+1. decide the correct release baseline and tag
+2. update `package.json`
+3. update `.release-please-manifest.json`
+4. repair `CHANGELOG.md` compare links
+5. confirm the latest real tag still matches the version source of truth before re-enabling automation

--- a/src/lib/release/automation.test.ts
+++ b/src/lib/release/automation.test.ts
@@ -1,0 +1,52 @@
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+describe("release automation source of truth", () => {
+  it("keeps release metadata aligned across package, manifest, workflow, and changelog", () => {
+    const root = process.cwd();
+    const packageJson = JSON.parse(readFileSync(path.join(root, "package.json"), "utf8")) as {
+      version: string;
+    };
+    const manifest = JSON.parse(
+      readFileSync(path.join(root, ".release-please-manifest.json"), "utf8")
+    ) as Record<string, string>;
+    const config = JSON.parse(
+      readFileSync(path.join(root, "release-please-config.json"), "utf8")
+    ) as {
+      [key: string]: unknown;
+      "bootstrap-sha"?: string;
+      "include-component-in-tag"?: boolean;
+    };
+    const workflow = readFileSync(
+      path.join(root, ".github", "workflows", "release-please.yml"),
+      "utf8"
+    );
+    const changelog = readFileSync(path.join(root, "CHANGELOG.md"), "utf8");
+
+    expect(manifest["."]).toBe(packageJson.version);
+    expect(config["include-component-in-tag"]).toBe(false);
+    expect(config["bootstrap-sha"]).toMatch(/^[0-9a-f]{40}$/u);
+    expect(workflow).toContain("config-file: release-please-config.json");
+    expect(workflow).toContain("manifest-file: .release-please-manifest.json");
+    expect(changelog).toContain(
+      `[unreleased]: https://github.com/abijith-suresh/tailory/compare/v${packageJson.version}...HEAD`
+    );
+  });
+
+  it("documents the maintainer release flow in-repo", () => {
+    const docPath = path.join(process.cwd(), "docs", "releases.md");
+
+    expect(existsSync(docPath)).toBe(true);
+
+    const docs = readFileSync(docPath, "utf8");
+
+    expect(docs).toContain("Release Please");
+    expect(docs).toContain("package.json");
+    expect(docs).toContain(".release-please-manifest.json");
+    expect(docs).toContain("CHANGELOG.md");
+    expect(docs).toContain("vX.Y.Z");
+    expect(docs).toContain("RELEASE_PLEASE_TOKEN");
+  });
+});


### PR DESCRIPTION
## Summary
Documents Tailory's Release Please flow and adds a small regression test that keeps the release source-of-truth files aligned. This turns the existing release setup into an explicitly documented, verifiable process for maintainers.

## Changes
- add maintainer-facing release documentation covering the source of truth, tag format, workflow, and recovery steps
- link the release notes from the main README so the guidance is easy to find
- add a Vitest guardrail that checks package, manifest, workflow, and changelog alignment

## Testing
- [x] bun run verify
- [x] bun run test -- src/lib/release/automation.test.ts

## References
- Ticket/Issue: Fixes #51