### PR TITLE
refactor: extract shared template section builders

### DIFF
--- a/src/lib/templates/compact-ats.ts
+++ b/src/lib/templates/compact-ats.ts
@@ -4,7 +4,6 @@ import type { TDocumentDefinitions } from "pdfmake/interfaces";
 import {
   buildProjectMetadata,
   formatContactLine,
-  formatDateRange,
   formatInterestsText,
   formatLanguagesText,
   formatSkillsText,
@@ -17,6 +16,17 @@ import {
   type ResumeDesignSettings,
 } from "@/lib/resume/design";
 import type { ResumeRenderModel, ResumeSectionModel } from "@/lib/templates/render-model";
+import {
+  buildAwardsSection,
+  buildCertificatesSection,
+  buildEducationSection,
+  buildProjectsSection,
+  buildPublicationsSection,
+  buildReferencesSection,
+  buildTextSection,
+  buildVolunteerSection,
+  buildWorkSection,
+} from "@/lib/templates/section-builders";
 
 // Compact ATS template: single column, dense layout, maximum keyword density.
 // Optimized for Applicant Tracking Systems: no tables, no images, standard fonts.
@@ -32,169 +42,98 @@ export function buildCompactAtsRenderModel(
   const languagesText = formatLanguagesText(resume.languages, { groupSeparator: " | " });
   const interestsText = formatInterestsText(resume.interests, { groupSeparator: " | " });
 
-  if (resume.basics.summary) {
-    sections.push({
+  const appendSection = (section: ResumeSectionModel | null) => {
+    if (section) {
+      sections.push(section);
+    }
+  };
+
+  appendSection(
+    buildTextSection({
       id: "summary",
-      kind: "text",
-      text: resume.basics.summary,
       title: "Summary",
+      text: resume.basics.summary,
       dividerAfter: true,
-    });
-  }
-
-  if (resume.work && resume.work.length > 0) {
-    sections.push({
-      id: "work",
-      kind: "entries",
+    })
+  );
+  appendSection(
+    buildWorkSection(resume.work, {
       title: "Professional Experience",
+      subtitleMode: "stacked",
       dividerAfter: true,
-      entries: resume.work.map((job) => ({
-        title: job.name,
-        subtitle: job.position,
-        subtitleMode: "stacked",
-        meta: formatDateRange(job.startDate, job.endDate),
-        body: job.summary,
-        bullets: job.highlights,
-      })),
-    });
-  }
-
-  if (resume.volunteer && resume.volunteer.length > 0) {
-    sections.push({
-      id: "volunteer",
-      kind: "entries",
+    })
+  );
+  appendSection(
+    buildVolunteerSection(resume.volunteer, {
       title: "Volunteer Experience",
+      subtitleMode: "stacked",
       dividerAfter: true,
-      entries: resume.volunteer.map((entry) => ({
-        title: entry.organization,
-        subtitle: entry.position,
-        subtitleMode: "stacked",
-        meta: formatDateRange(entry.startDate, entry.endDate),
-        body: entry.summary,
-        bullets: entry.highlights,
-      })),
-    });
-  }
-
-  if (resume.education && resume.education.length > 0) {
-    sections.push({
-      id: "education",
-      kind: "entries",
+    })
+  );
+  appendSection(
+    buildEducationSection(resume.education, {
       title: "Education",
+      subtitleMode: "stacked",
       dividerAfter: true,
-      entries: resume.education.map((education) => ({
-        title: education.institution,
-        subtitle: [education.studyType, education.area].filter(Boolean).join(", "),
-        subtitleMode: "stacked",
-        meta: formatDateRange(education.startDate, education.endDate),
-        details: education.score ? [`GPA: ${education.score}`] : undefined,
-      })),
-    });
-  }
-
-  if (resume.awards && resume.awards.length > 0) {
-    sections.push({
-      id: "awards",
-      kind: "entries",
+    })
+  );
+  appendSection(
+    buildAwardsSection(resume.awards, {
       title: "Awards",
+      subtitleMode: "stacked",
       dividerAfter: true,
-      entries: resume.awards.map((award) => ({
-        title: award.title,
-        subtitle: award.awarder,
-        subtitleMode: "stacked",
-        meta: award.date,
-        body: award.summary,
-      })),
-    });
-  }
-
-  if (resume.publications && resume.publications.length > 0) {
-    sections.push({
-      id: "publications",
-      kind: "entries",
+    })
+  );
+  appendSection(
+    buildPublicationsSection(resume.publications, {
       title: "Publications",
+      subtitleMode: "stacked",
       dividerAfter: true,
-      entries: resume.publications.map((publication) => ({
-        title: publication.name,
-        subtitle: publication.publisher,
-        subtitleMode: "stacked",
-        meta: publication.releaseDate,
-        body: publication.summary,
-      })),
-    });
-  }
-
-  if (skillsText) {
-    sections.push({
+    })
+  );
+  appendSection(
+    buildTextSection({
       id: "skills",
-      kind: "text",
-      text: skillsText,
       title: "Technical Skills",
+      text: skillsText,
       dividerAfter: true,
-    });
-  }
-
-  if (languagesText) {
-    sections.push({
+    })
+  );
+  appendSection(
+    buildTextSection({
       id: "languages",
-      kind: "text",
-      text: languagesText,
       title: "Languages",
+      text: languagesText,
       dividerAfter: true,
-    });
-  }
-
-  if (interestsText) {
-    sections.push({
+    })
+  );
+  appendSection(
+    buildTextSection({
       id: "interests",
-      kind: "text",
-      text: interestsText,
       title: "Interests",
+      text: interestsText,
       dividerAfter: true,
-    });
-  }
-
-  if (resume.projects && resume.projects.length > 0) {
-    sections.push({
-      id: "projects",
-      kind: "entries",
+    })
+  );
+  appendSection(
+    buildProjectsSection(resume.projects, {
       title: "Projects",
       dividerAfter: true,
-      entries: resume.projects.map((project) => ({
-        title: project.name,
-        meta: buildProjectMetadata(project),
-        body: project.description,
-        bullets: project.highlights,
-      })),
-    });
-  }
-
-  if (resume.references && resume.references.length > 0) {
-    sections.push({
-      id: "references",
-      kind: "entries",
+      resolveMeta: (project) => buildProjectMetadata(project),
+    })
+  );
+  appendSection(
+    buildReferencesSection(resume.references, {
       title: "References",
       dividerAfter: true,
-      entries: resume.references.map((reference) => ({
-        title: reference.name,
-        body: reference.reference,
-      })),
-    });
-  }
-
-  if (resume.certificates && resume.certificates.length > 0) {
-    sections.push({
-      id: "certificates",
-      kind: "entries",
+    })
+  );
+  appendSection(
+    buildCertificatesSection(resume.certificates, {
       title: "Certifications",
-      entries: resume.certificates.map((certificate) => ({
-        title: certificate.name,
-        subtitle: certificate.issuer,
-        subtitleMode: "stacked",
-        meta: certificate.date,
-      })),
-    });
-  }
+      subtitleMode: "stacked",
+    })
+  );
 
   return {
     template: "compact-ats",

--- a/src/lib/templates/minimal.ts
+++ b/src/lib/templates/minimal.ts
@@ -3,12 +3,10 @@ import type { TDocumentDefinitions } from "pdfmake/interfaces";
 
 import {
   formatContactLine,
-  formatDateRange,
   formatDisplayUrl,
   formatInterestsText,
   formatLanguagesText,
   formatSkillsText,
-  joinDefined,
 } from "@/lib/export/template-helpers";
 import { renderPdfResumeModel } from "@/lib/export/pdf-renderer";
 import type { PdfTemplateOptions } from "@/lib/export/template-types";
@@ -18,6 +16,17 @@ import {
   type ResumeDesignSettings,
 } from "@/lib/resume/design";
 import type { ResumeRenderModel, ResumeSectionModel } from "@/lib/templates/render-model";
+import {
+  buildAwardsSection,
+  buildCertificatesSection,
+  buildEducationSection,
+  buildProjectsSection,
+  buildPublicationsSection,
+  buildReferencesSection,
+  buildTextSection,
+  buildVolunteerSection,
+  buildWorkSection,
+} from "@/lib/templates/section-builders";
 
 const PAGE_MARGINS = [50, 50, 50, 50] as const;
 
@@ -30,139 +39,44 @@ export function buildMinimalRenderModel(
   const interestsText = formatInterestsText(resume.interests, { groupSeparator: ", " });
   const sections: ResumeSectionModel[] = [];
 
-  if (resume.basics.summary) {
-    sections.push({ id: "summary", kind: "text", text: resume.basics.summary, title: "Summary" });
-  }
+  const appendSection = (section: ResumeSectionModel | null) => {
+    if (section) {
+      sections.push(section);
+    }
+  };
 
-  if (resume.work && resume.work.length > 0) {
-    sections.push({
-      id: "work",
-      kind: "entries",
-      title: "Experience",
-      entries: resume.work.map((job) => ({
-        title: job.name,
-        subtitle: job.position,
-        subtitleMode: "inline",
-        meta: formatDateRange(job.startDate, job.endDate),
-        body: job.summary,
-        bullets: job.highlights,
-      })),
-    });
-  }
-
-  if (resume.volunteer && resume.volunteer.length > 0) {
-    sections.push({
-      id: "volunteer",
-      kind: "entries",
-      title: "Volunteer",
-      entries: resume.volunteer.map((entry) => ({
-        title: entry.organization,
-        subtitle: entry.position,
-        subtitleMode: "inline",
-        meta: formatDateRange(entry.startDate, entry.endDate),
-        body: entry.summary,
-        bullets: entry.highlights,
-      })),
-    });
-  }
-
-  if (resume.education && resume.education.length > 0) {
-    sections.push({
-      id: "education",
-      kind: "entries",
-      title: "Education",
-      entries: resume.education.map((education) => ({
-        title: education.institution,
-        subtitle: joinDefined([education.studyType, education.area], ", "),
-        subtitleMode: "inline",
-        meta: formatDateRange(education.startDate, education.endDate),
-        details: education.score ? [`GPA: ${education.score}`] : undefined,
-      })),
-    });
-  }
-
-  if (resume.awards && resume.awards.length > 0) {
-    sections.push({
-      id: "awards",
-      kind: "entries",
-      title: "Awards",
-      entries: resume.awards.map((award) => ({
-        title: award.title,
-        subtitle: award.awarder,
-        subtitleMode: "inline",
-        meta: award.date,
-        body: award.summary,
-      })),
-    });
-  }
-
-  if (resume.publications && resume.publications.length > 0) {
-    sections.push({
-      id: "publications",
-      kind: "entries",
+  appendSection(buildTextSection({ id: "summary", title: "Summary", text: resume.basics.summary }));
+  appendSection(buildWorkSection(resume.work, { title: "Experience", subtitleMode: "inline" }));
+  appendSection(
+    buildVolunteerSection(resume.volunteer, { title: "Volunteer", subtitleMode: "inline" })
+  );
+  appendSection(
+    buildEducationSection(resume.education, { title: "Education", subtitleMode: "inline" })
+  );
+  appendSection(buildAwardsSection(resume.awards, { title: "Awards", subtitleMode: "inline" }));
+  appendSection(
+    buildPublicationsSection(resume.publications, {
       title: "Publications",
-      entries: resume.publications.map((publication) => ({
-        title: publication.name,
-        subtitle: publication.publisher,
-        subtitleMode: "inline",
-        meta: publication.releaseDate,
-        body: publication.summary,
-        link: formatDisplayUrl(publication.url),
-      })),
-    });
-  }
-
-  if (skillsText) {
-    sections.push({ id: "skills", kind: "text", text: skillsText, title: "Skills" });
-  }
-
-  if (languagesText) {
-    sections.push({ id: "languages", kind: "text", text: languagesText, title: "Languages" });
-  }
-
-  if (interestsText) {
-    sections.push({ id: "interests", kind: "text", text: interestsText, title: "Interests" });
-  }
-
-  if (resume.projects && resume.projects.length > 0) {
-    sections.push({
-      id: "projects",
-      kind: "entries",
+      subtitleMode: "inline",
+      resolveLink: (url) => formatDisplayUrl(url),
+    })
+  );
+  appendSection(buildTextSection({ id: "skills", title: "Skills", text: skillsText }));
+  appendSection(buildTextSection({ id: "languages", title: "Languages", text: languagesText }));
+  appendSection(buildTextSection({ id: "interests", title: "Interests", text: interestsText }));
+  appendSection(
+    buildProjectsSection(resume.projects, {
       title: "Projects",
-      entries: resume.projects.map((project) => ({
-        title: project.name,
-        meta: formatDisplayUrl(project.url),
-        body: project.description,
-        bullets: project.highlights,
-      })),
-    });
-  }
-
-  if (resume.references && resume.references.length > 0) {
-    sections.push({
-      id: "references",
-      kind: "entries",
-      title: "References",
-      entries: resume.references.map((reference) => ({
-        title: reference.name,
-        body: reference.reference,
-      })),
-    });
-  }
-
-  if (resume.certificates && resume.certificates.length > 0) {
-    sections.push({
-      id: "certificates",
-      kind: "entries",
+      resolveMeta: (project) => formatDisplayUrl(project.url),
+    })
+  );
+  appendSection(buildReferencesSection(resume.references, { title: "References" }));
+  appendSection(
+    buildCertificatesSection(resume.certificates, {
       title: "Certifications",
-      entries: resume.certificates.map((certificate) => ({
-        title: certificate.name,
-        subtitle: certificate.issuer,
-        subtitleMode: "inline",
-        meta: certificate.date,
-      })),
-    });
-  }
+      subtitleMode: "inline",
+    })
+  );
 
   return {
     template: "minimal",

--- a/src/lib/templates/modern.ts
+++ b/src/lib/templates/modern.ts
@@ -4,7 +4,6 @@ import type { TDocumentDefinitions } from "pdfmake/interfaces";
 import {
   buildProjectMetadata,
   formatContactLine,
-  formatDateRange,
   formatDisplayUrl,
   formatInterestsText,
   formatLanguagesText,
@@ -18,6 +17,17 @@ import {
   type ResumeDesignSettings,
 } from "@/lib/resume/design";
 import type { ResumeRenderModel, ResumeSectionModel } from "@/lib/templates/render-model";
+import {
+  buildAwardsSection,
+  buildCertificatesSection,
+  buildEducationSection,
+  buildProjectsSection,
+  buildPublicationsSection,
+  buildReferencesSection,
+  buildTextSection,
+  buildVolunteerSection,
+  buildWorkSection,
+} from "@/lib/templates/section-builders";
 
 const PAGE_MARGINS = [45, 45, 45, 45] as const;
 
@@ -30,147 +40,72 @@ export function buildModernRenderModel(
   const languagesText = formatLanguagesText(resume.languages, { groupSeparator: " | " });
   const interestsText = formatInterestsText(resume.interests, { groupSeparator: " | " });
 
-  if (resume.basics.summary) {
-    sections.push({ id: "summary", kind: "text", text: resume.basics.summary, title: "Summary" });
-  }
+  const appendSection = (section: ResumeSectionModel | null) => {
+    if (section) {
+      sections.push(section);
+    }
+  };
 
-  if (resume.work && resume.work.length > 0) {
-    sections.push({
-      id: "work",
-      kind: "entries",
+  appendSection(buildTextSection({ id: "summary", title: "Summary", text: resume.basics.summary }));
+  appendSection(
+    buildWorkSection(resume.work, {
       title: "Experience",
-      entries: resume.work.map((job) => ({
-        title: job.name,
-        subtitle: job.position,
-        subtitleMode: "stacked",
-        meta: formatDateRange(job.startDate, job.endDate),
-        body: job.summary,
-        bullets: job.highlights,
-        spacerAfter: 6,
-      })),
-    });
-  }
-
-  if (resume.volunteer && resume.volunteer.length > 0) {
-    sections.push({
-      id: "volunteer",
-      kind: "entries",
+      subtitleMode: "stacked",
+      spacerAfter: 6,
+    })
+  );
+  appendSection(
+    buildVolunteerSection(resume.volunteer, {
       title: "Volunteer",
-      entries: resume.volunteer.map((entry) => ({
-        title: entry.organization,
-        subtitle: entry.position,
-        subtitleMode: "stacked",
-        meta: formatDateRange(entry.startDate, entry.endDate),
-        body: entry.summary,
-        bullets: entry.highlights,
-        spacerAfter: 6,
-      })),
-    });
-  }
-
-  if (resume.education && resume.education.length > 0) {
-    sections.push({
-      id: "education",
-      kind: "entries",
+      subtitleMode: "stacked",
+      spacerAfter: 6,
+    })
+  );
+  appendSection(
+    buildEducationSection(resume.education, {
       title: "Education",
-      entries: resume.education.map((education) => ({
-        title: education.institution,
-        subtitle: [education.studyType, education.area].filter(Boolean).join(", "),
-        subtitleMode: "stacked",
-        meta: formatDateRange(education.startDate, education.endDate),
-        details: education.score ? [`GPA: ${education.score}`] : undefined,
-        spacerAfter: 4,
-      })),
-    });
-  }
-
-  if (resume.awards && resume.awards.length > 0) {
-    sections.push({
-      id: "awards",
-      kind: "entries",
+      subtitleMode: "stacked",
+      spacerAfter: 4,
+    })
+  );
+  appendSection(
+    buildAwardsSection(resume.awards, {
       title: "Awards",
-      entries: resume.awards.map((award) => ({
-        title: award.title,
-        subtitle: award.awarder,
-        subtitleMode: "stacked",
-        meta: award.date,
-        body: award.summary,
-        spacerAfter: 4,
-      })),
-    });
-  }
-
-  if (resume.publications && resume.publications.length > 0) {
-    sections.push({
-      id: "publications",
-      kind: "entries",
+      subtitleMode: "stacked",
+      spacerAfter: 4,
+    })
+  );
+  appendSection(
+    buildPublicationsSection(resume.publications, {
       title: "Publications",
-      entries: resume.publications.map((publication) => ({
-        title: publication.name,
-        subtitle: publication.publisher,
-        subtitleMode: "stacked",
-        meta: publication.releaseDate,
-        body: publication.summary,
-        link: publication.url ? (formatDisplayUrl(publication.url) ?? publication.url) : undefined,
-        spacerAfter: 4,
-      })),
-    });
-  }
-
-  if (skillsText) {
-    sections.push({ id: "skills", kind: "text", text: skillsText, title: "Skills" });
-  }
-
-  if (languagesText) {
-    sections.push({ id: "languages", kind: "text", text: languagesText, title: "Languages" });
-  }
-
-  if (interestsText) {
-    sections.push({ id: "interests", kind: "text", text: interestsText, title: "Interests" });
-  }
-
-  if (resume.projects && resume.projects.length > 0) {
-    sections.push({
-      id: "projects",
-      kind: "entries",
+      subtitleMode: "stacked",
+      spacerAfter: 4,
+      resolveLink: (url) => (url ? (formatDisplayUrl(url) ?? url) : undefined),
+    })
+  );
+  appendSection(buildTextSection({ id: "skills", title: "Skills", text: skillsText }));
+  appendSection(buildTextSection({ id: "languages", title: "Languages", text: languagesText }));
+  appendSection(buildTextSection({ id: "interests", title: "Interests", text: interestsText }));
+  appendSection(
+    buildProjectsSection(resume.projects, {
       title: "Projects",
-      entries: resume.projects.map((project) => ({
-        title: project.name,
-        meta: buildProjectMetadata(project),
-        body: project.description,
-        bullets: project.highlights,
-        link: project.url ? (formatDisplayUrl(project.url) ?? project.url) : undefined,
-        spacerAfter: 4,
-      })),
-    });
-  }
-
-  if (resume.references && resume.references.length > 0) {
-    sections.push({
-      id: "references",
-      kind: "entries",
+      spacerAfter: 4,
+      resolveMeta: (project) => buildProjectMetadata(project),
+      resolveLink: (url) => (url ? (formatDisplayUrl(url) ?? url) : undefined),
+    })
+  );
+  appendSection(
+    buildReferencesSection(resume.references, {
       title: "References",
-      entries: resume.references.map((reference) => ({
-        title: reference.name,
-        body: reference.reference,
-        spacerAfter: 4,
-      })),
-    });
-  }
-
-  if (resume.certificates && resume.certificates.length > 0) {
-    sections.push({
-      id: "certificates",
-      kind: "entries",
+      spacerAfter: 4,
+    })
+  );
+  appendSection(
+    buildCertificatesSection(resume.certificates, {
       title: "Certifications",
-      entries: resume.certificates.map((certificate) => ({
-        title: certificate.name,
-        subtitle: certificate.issuer,
-        subtitleMode: "stacked",
-        meta: certificate.date,
-      })),
-    });
-  }
+      subtitleMode: "stacked",
+    })
+  );
 
   return {
     template: "modern",

--- a/src/lib/templates/section-builders.ts
+++ b/src/lib/templates/section-builders.ts
@@ -1,0 +1,253 @@
+import { formatDateRange, joinDefined } from "@/lib/export/template-helpers";
+import type {
+  ResumeAward,
+  ResumeCertificate,
+  ResumeEducation,
+  ResumeProject,
+  ResumePublication,
+  ResumeReference,
+  ResumeVolunteer,
+  ResumeWork,
+} from "@/types/resume";
+
+import type { ResumeEntryModel, ResumeSectionModel } from "./render-model";
+
+type SectionId = ResumeSectionModel["id"];
+
+type SectionDividerOption = Pick<ResumeSectionModel, "dividerAfter">;
+
+type EntryLayoutOptions = {
+  spacerAfter?: number;
+  subtitleMode?: ResumeEntryModel["subtitleMode"];
+};
+
+interface TextSectionOptions extends SectionDividerOption {
+  id: Extract<SectionId, "summary" | "skills" | "languages" | "interests">;
+  text: string | undefined;
+  title: string;
+}
+
+interface EntrySectionOptions<T> extends EntryLayoutOptions, SectionDividerOption {
+  entries: T[] | undefined;
+  id: Exclude<SectionId, "summary" | "skills" | "languages" | "interests">;
+  mapEntry: (entry: T) => ResumeEntryModel;
+  title: string;
+}
+
+interface RoleSectionOptions extends EntryLayoutOptions, SectionDividerOption {
+  title: string;
+}
+
+interface PublicationSectionOptions extends EntryLayoutOptions, SectionDividerOption {
+  resolveLink?: (url?: string) => string | undefined;
+  title: string;
+}
+
+interface ProjectSectionOptions extends EntryLayoutOptions, SectionDividerOption {
+  resolveLink?: (url?: string) => string | undefined;
+  resolveMeta?: (project: ResumeProject) => string | undefined;
+  title: string;
+}
+
+function hasEntries<T>(entries: T[] | undefined): entries is T[] {
+  return Array.isArray(entries) && entries.length > 0;
+}
+
+function buildEntriesSection<T>(options: EntrySectionOptions<T>): ResumeSectionModel | null {
+  if (!hasEntries(options.entries)) {
+    return null;
+  }
+
+  return {
+    id: options.id,
+    kind: "entries",
+    title: options.title,
+    dividerAfter: options.dividerAfter,
+    entries: options.entries.map(options.mapEntry),
+  };
+}
+
+function buildRoleEntriesSection<T extends ResumeWork | ResumeVolunteer>(
+  options: RoleSectionOptions & {
+    entries: T[] | undefined;
+    getTitle: (entry: T) => string;
+    id: Extract<SectionId, "work" | "volunteer">;
+  }
+): ResumeSectionModel | null {
+  return buildEntriesSection({
+    id: options.id,
+    title: options.title,
+    dividerAfter: options.dividerAfter,
+    entries: options.entries,
+    mapEntry: (entry) => ({
+      title: options.getTitle(entry),
+      subtitle: entry.position,
+      subtitleMode: options.subtitleMode,
+      meta: formatDateRange(entry.startDate, entry.endDate),
+      body: entry.summary,
+      bullets: entry.highlights,
+      spacerAfter: options.spacerAfter,
+    }),
+  });
+}
+
+export function buildTextSection(options: TextSectionOptions): ResumeSectionModel | null {
+  if (!options.text) {
+    return null;
+  }
+
+  return {
+    id: options.id,
+    kind: "text",
+    title: options.title,
+    text: options.text,
+    dividerAfter: options.dividerAfter,
+  };
+}
+
+export function buildWorkSection(
+  work: ResumeWork[] | undefined,
+  options: RoleSectionOptions
+): ResumeSectionModel | null {
+  return buildRoleEntriesSection({
+    id: "work",
+    entries: work,
+    title: options.title,
+    dividerAfter: options.dividerAfter,
+    subtitleMode: options.subtitleMode,
+    spacerAfter: options.spacerAfter,
+    getTitle: (entry) => entry.name,
+  });
+}
+
+export function buildVolunteerSection(
+  volunteer: ResumeVolunteer[] | undefined,
+  options: RoleSectionOptions
+): ResumeSectionModel | null {
+  return buildRoleEntriesSection({
+    id: "volunteer",
+    entries: volunteer,
+    title: options.title,
+    dividerAfter: options.dividerAfter,
+    subtitleMode: options.subtitleMode,
+    spacerAfter: options.spacerAfter,
+    getTitle: (entry) => entry.organization,
+  });
+}
+
+export function buildEducationSection(
+  education: ResumeEducation[] | undefined,
+  options: RoleSectionOptions
+): ResumeSectionModel | null {
+  return buildEntriesSection({
+    id: "education",
+    title: options.title,
+    dividerAfter: options.dividerAfter,
+    entries: education,
+    mapEntry: (entry) => ({
+      title: entry.institution,
+      subtitle: joinDefined([entry.studyType, entry.area], ", "),
+      subtitleMode: options.subtitleMode,
+      meta: formatDateRange(entry.startDate, entry.endDate),
+      details: entry.score ? [`GPA: ${entry.score}`] : undefined,
+      spacerAfter: options.spacerAfter,
+    }),
+  });
+}
+
+export function buildAwardsSection(
+  awards: ResumeAward[] | undefined,
+  options: RoleSectionOptions
+): ResumeSectionModel | null {
+  return buildEntriesSection({
+    id: "awards",
+    title: options.title,
+    dividerAfter: options.dividerAfter,
+    entries: awards,
+    mapEntry: (entry) => ({
+      title: entry.title,
+      subtitle: entry.awarder,
+      subtitleMode: options.subtitleMode,
+      meta: entry.date,
+      body: entry.summary,
+      spacerAfter: options.spacerAfter,
+    }),
+  });
+}
+
+export function buildPublicationsSection(
+  publications: ResumePublication[] | undefined,
+  options: PublicationSectionOptions
+): ResumeSectionModel | null {
+  return buildEntriesSection({
+    id: "publications",
+    title: options.title,
+    dividerAfter: options.dividerAfter,
+    entries: publications,
+    mapEntry: (entry) => ({
+      title: entry.name,
+      subtitle: entry.publisher,
+      subtitleMode: options.subtitleMode,
+      meta: entry.releaseDate,
+      body: entry.summary,
+      link: options.resolveLink?.(entry.url),
+      spacerAfter: options.spacerAfter,
+    }),
+  });
+}
+
+export function buildProjectsSection(
+  projects: ResumeProject[] | undefined,
+  options: ProjectSectionOptions
+): ResumeSectionModel | null {
+  return buildEntriesSection({
+    id: "projects",
+    title: options.title,
+    dividerAfter: options.dividerAfter,
+    entries: projects,
+    mapEntry: (entry) => ({
+      title: entry.name,
+      meta: options.resolveMeta?.(entry),
+      body: entry.description,
+      bullets: entry.highlights,
+      link: options.resolveLink?.(entry.url),
+      spacerAfter: options.spacerAfter,
+    }),
+  });
+}
+
+export function buildReferencesSection(
+  references: ResumeReference[] | undefined,
+  options: SectionDividerOption & Pick<EntryLayoutOptions, "spacerAfter"> & { title: string }
+): ResumeSectionModel | null {
+  return buildEntriesSection({
+    id: "references",
+    title: options.title,
+    dividerAfter: options.dividerAfter,
+    entries: references,
+    mapEntry: (entry) => ({
+      title: entry.name,
+      body: entry.reference,
+      spacerAfter: options.spacerAfter,
+    }),
+  });
+}
+
+export function buildCertificatesSection(
+  certificates: ResumeCertificate[] | undefined,
+  options: RoleSectionOptions
+): ResumeSectionModel | null {
+  return buildEntriesSection({
+    id: "certificates",
+    title: options.title,
+    dividerAfter: options.dividerAfter,
+    entries: certificates,
+    mapEntry: (entry) => ({
+      title: entry.name,
+      subtitle: entry.issuer,
+      subtitleMode: options.subtitleMode,
+      meta: entry.date,
+      spacerAfter: options.spacerAfter,
+    }),
+  });
+}


### PR DESCRIPTION
## Summary
Extracts shared section-building primitives from the three resume templates so new templates can reuse common section mapping instead of copying large blocks of logic. Existing template behavior stays the same while the render-model layer becomes easier to extend.

## Changes
- add shared section builder helpers for text, dated-entry, publication, project, reference, and certificate sections
- refactor the minimal, modern, and compact ATS templates to compose those shared helpers instead of repeating section assembly logic
- keep existing render-model behavior and template-specific layout choices covered by the current test suite

## Testing
- [x] bun run verify
- [x] bun run test -- src/lib/templates/minimal.test.ts src/lib/templates/modern.test.ts src/lib/templates/compact-ats.test.ts

## References
- Ticket/Issue: Fixes #55