### PR TITLE
feat: tighten JSON Resume compatibility rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Tailory can import and export JSON Resume-style documents for the fields it curr
 - unsupported or non-standard shapes may be rejected or normalized away
 - some fields Tailory can preserve or render are still not exposed in the editor UI
 
+Compatibility details live in [docs/json-resume.md](./docs/json-resume.md).
+
 ## Privacy and storage
 
 Tailory has no application backend, no accounts, and no server-side resume processing. Your resume data stays in your browser unless **you** choose to export or share it.

--- a/docs/json-resume.md
+++ b/docs/json-resume.md
@@ -1,0 +1,55 @@
+# JSON Resume compatibility
+
+Tailory supports **JSON Resume-style** import and export for the fields it currently models in its own resume schema.
+
+## Supported top-level sections
+
+Tailory currently accepts and exports these top-level sections:
+
+- `basics`
+- `work`
+- `volunteer`
+- `education`
+- `awards`
+- `certificates`
+- `publications`
+- `skills`
+- `languages`
+- `interests`
+- `references`
+- `projects`
+
+## Metadata fields
+
+Tailory ignores these common non-content fields during import:
+
+- `$schema`
+- `meta`
+
+## Compatibility rules
+
+- Tailory normalizes supported content into its internal resume schema on import.
+- Internal entry IDs are removed again during export.
+- Unknown top-level fields fail fast with an actionable error instead of being silently dropped.
+- Empty or malformed section shapes fail with explicit validation messages.
+- Tailory does **not** currently claim full validation against the upstream official JSON Resume schema package.
+
+## Editor coverage vs data coverage
+
+Not every supported JSON Resume field is fully editable in the current form UI.
+
+Today Tailory can already preserve and render more schema-backed content than the editor exposes directly. In practice that means some sections may:
+
+- import successfully
+- survive normalization and JSON export
+- appear in preview and PDF export
+- still lack first-class editor controls
+
+## What to expect from invalid files
+
+Tailory rejects JSON files when:
+
+- the top-level document is not an object
+- a supported section has the wrong shape, such as `work` being an object instead of an array
+- the document is missing basic identity information such as `basics.name`, `basics.email`, or `basics.label`
+- the document includes unsupported top-level fields that Tailory would otherwise have to drop

--- a/src/lib/resume/json.test.ts
+++ b/src/lib/resume/json.test.ts
@@ -94,6 +94,30 @@ describe("JSON Resume parsing", () => {
     ).toThrowError("Invalid JSON Resume: 'work' must be an array.");
   });
 
+  it("rejects unsupported top-level fields with actionable feedback", () => {
+    expect(() =>
+      parseJsonResumeDocument({
+        basics: { name: "Jane Doe" },
+        portfolio: { website: "https://janedoe.dev" },
+      })
+    ).toThrowError(
+      "Unsupported JSON Resume fields: portfolio. Tailory currently supports basics, work, volunteer, education, awards, certificates, publications, skills, languages, interests, references, and projects."
+    );
+  });
+
+  it("ignores JSON Resume metadata fields that Tailory does not store", () => {
+    const parsed = parseJsonResumeDocument({
+      $schema: "https://jsonresume.org/schema",
+      meta: { theme: "kendall" },
+      basics: { name: "Jane Doe", email: "jane@example.com" },
+    });
+
+    expect(parsed.basics).toMatchObject({
+      name: "Jane Doe",
+      email: "jane@example.com",
+    });
+  });
+
   it("rejects documents without basic identity fields", () => {
     expect(() =>
       parseJsonResumeDocument({

--- a/src/lib/resume/json.ts
+++ b/src/lib/resume/json.ts
@@ -14,6 +14,28 @@ import type {
   ResumeWork,
 } from "@/types/resume";
 
+export const JSON_RESUME_SUPPORTED_TOP_LEVEL_FIELDS = [
+  "basics",
+  "work",
+  "volunteer",
+  "education",
+  "awards",
+  "certificates",
+  "publications",
+  "skills",
+  "languages",
+  "interests",
+  "references",
+  "projects",
+] as const;
+
+export const JSON_RESUME_IGNORED_TOP_LEVEL_FIELDS = ["$schema", "meta"] as const;
+
+const JSON_RESUME_ALLOWED_TOP_LEVEL_FIELDS = new Set<string>([
+  ...JSON_RESUME_SUPPORTED_TOP_LEVEL_FIELDS,
+  ...JSON_RESUME_IGNORED_TOP_LEVEL_FIELDS,
+]);
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -100,9 +122,32 @@ export function parseJsonResumeString(source: string): ResumeSchema {
   return parseJsonResumeDocument(parsed);
 }
 
+function findUnsupportedTopLevelFields(document: Record<string, unknown>): string[] {
+  return Object.keys(document).filter((key) => !JSON_RESUME_ALLOWED_TOP_LEVEL_FIELDS.has(key));
+}
+
+function formatSupportedTopLevelFields(): string {
+  const fields = [...JSON_RESUME_SUPPORTED_TOP_LEVEL_FIELDS];
+  const lastField = fields.pop();
+
+  if (!lastField) {
+    return "";
+  }
+
+  return fields.length > 0 ? `${fields.join(", ")}, and ${lastField}` : lastField;
+}
+
 export function parseJsonResumeDocument(document: unknown): ResumeSchema {
   if (!isRecord(document)) {
     throw new Error("Invalid JSON Resume: top-level document must be an object.");
+  }
+
+  const unsupportedFields = findUnsupportedTopLevelFields(document);
+
+  if (unsupportedFields.length > 0) {
+    throw new Error(
+      `Unsupported JSON Resume fields: ${unsupportedFields.join(", ")}. Tailory currently supports ${formatSupportedTopLevelFields()}.`
+    );
   }
 
   const normalized = normalizeResume({


### PR DESCRIPTION
## Summary
Makes Tailory's JSON Resume support explicit, documented, and testable. Supported sections are now documented in-repo, common metadata fields are ignored intentionally, and unsupported top-level fields fail fast instead of being silently dropped.

## Changes
- reject unsupported top-level JSON Resume fields with actionable error messages while still allowing `$schema` and `meta`
- add targeted parsing tests for unsupported fields and ignored metadata behavior
- document Tailory's current JSON Resume compatibility rules and link them from the README

## Testing
- [x] bun run verify
- [x] bun run test -- src/lib/resume/json.test.ts

## References
- Ticket/Issue: Fixes #7