### PR TITLE
fix: prevent autosave from overriding explicit entry flows

### DIFF
--- a/src/components/editor/CommandBar.tsx
+++ b/src/components/editor/CommandBar.tsx
@@ -96,9 +96,7 @@ const CommandBar: Component = () => {
       return;
     }
 
-    if (outcome.feedback) {
-      setImportFeedback(outcome.feedback);
-    }
+    setImportFeedback(outcome.feedback ?? null);
     loadResume(outcome.resume);
   };
 

--- a/src/components/editor/DraftManager.tsx
+++ b/src/components/editor/DraftManager.tsx
@@ -8,6 +8,8 @@ import {
   Show,
 } from "solid-js";
 
+import { initializeAutosaveSession } from "@/lib/editor/autosave-session";
+import { consumeEditorEntryMode } from "@/lib/editor/session-entry";
 import {
   AUTOSAVE_DRAFT_ID,
   deleteDraft,
@@ -16,7 +18,7 @@ import {
   saveDraft,
 } from "@/lib/storage/db";
 import { serializeNormalizedResume } from "@/lib/resume/normalize";
-import { cloneResumeData, restoreAutosaveDraft, saveAutosaveDraft } from "@/lib/storage/drafts";
+import { cloneResumeData, saveAutosaveDraft } from "@/lib/storage/drafts";
 import { loadResume, resume } from "@/store/resume";
 
 type Status = "idle" | "saving" | "saved" | "error";
@@ -51,7 +53,8 @@ const DraftManager: Component<DraftManagerProps> = (props) => {
   };
 
   onMount(async () => {
-    const restored = await restoreAutosaveDraft();
+    const entryMode = consumeEditorEntryMode();
+    const restored = await initializeAutosaveSession(entryMode, resume);
     setStorageAvailable(restored.available);
 
     if (!restored.available) {
@@ -62,6 +65,8 @@ const DraftManager: Component<DraftManagerProps> = (props) => {
     if (restored.draft) {
       setLastAutosaveSnapshot(restored.snapshotJson);
       loadResume(restored.draft.resumeData);
+    } else if (restored.snapshotJson) {
+      setLastAutosaveSnapshot(restored.snapshotJson);
     }
 
     setHasHydratedAutosave(true);

--- a/src/components/upload/FileUpload.tsx
+++ b/src/components/upload/FileUpload.tsx
@@ -1,9 +1,10 @@
 import { type Component, createSignal, Show } from "solid-js";
 
 import ProcessingIndicator from "@/components/ui/ProcessingIndicator";
+import { queueEditorEntryMode } from "@/lib/editor/session-entry";
 import { importResumeFile } from "@/lib/upload/import-resume";
 import { validateUploadFile } from "@/lib/upload/guardrails";
-import { loadResume, setImportFeedback } from "@/store/resume";
+import { loadResume, resetResume, setImportFeedback } from "@/store/resume";
 
 type Status = "idle" | "processing" | "error";
 
@@ -31,9 +32,8 @@ const FileUpload: Component = () => {
       return;
     }
 
-    if (outcome.feedback) {
-      setImportFeedback(outcome.feedback);
-    }
+    queueEditorEntryMode("import");
+    setImportFeedback(outcome.feedback ?? null);
     loadResume(outcome.resume);
 
     // Navigate to editor with client-side transition
@@ -62,6 +62,10 @@ const FileUpload: Component = () => {
   const handleDragLeave = () => setIsDragOver(false);
 
   const startFromScratch = async () => {
+    queueEditorEntryMode("blank");
+    setImportFeedback(null);
+    resetResume();
+
     const { navigate } = await import("astro:transitions/client");
     navigate("/editor");
   };

--- a/src/lib/editor/autosave-session.test.ts
+++ b/src/lib/editor/autosave-session.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { serializeNormalizedResume } from "@/lib/resume/normalize";
+import { EMPTY_RESUME } from "@/types/resume";
+
+const restoreAutosaveDraft = vi.fn();
+const saveAutosaveDraft = vi.fn();
+
+vi.mock("@/lib/storage/drafts", () => ({
+  restoreAutosaveDraft,
+  saveAutosaveDraft,
+}));
+
+describe("initializeAutosaveSession", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("restores autosave drafts for normal editor entry", async () => {
+    restoreAutosaveDraft.mockResolvedValue({
+      available: true,
+      draft: {
+        id: "autosave",
+        name: "Autosave",
+        createdAt: 1,
+        updatedAt: 1,
+        resumeData: EMPTY_RESUME,
+      },
+      snapshotJson: JSON.stringify(EMPTY_RESUME),
+    });
+
+    const { initializeAutosaveSession } = await import("./autosave-session");
+
+    await expect(
+      initializeAutosaveSession("restore-autosave", structuredClone(EMPTY_RESUME))
+    ).resolves.toEqual({
+      available: true,
+      draft: {
+        id: "autosave",
+        name: "Autosave",
+        createdAt: 1,
+        updatedAt: 1,
+        resumeData: EMPTY_RESUME,
+      },
+      snapshotJson: JSON.stringify(EMPTY_RESUME),
+    });
+    expect(saveAutosaveDraft).not.toHaveBeenCalled();
+  });
+
+  it("persists the current resume instead of restoring autosave for blank and import entry", async () => {
+    saveAutosaveDraft.mockResolvedValue(true);
+
+    const { initializeAutosaveSession } = await import("./autosave-session");
+    const importedResume = {
+      ...structuredClone(EMPTY_RESUME),
+      basics: {
+        ...structuredClone(EMPTY_RESUME.basics),
+        name: "Jane Doe",
+      },
+    };
+
+    await expect(
+      initializeAutosaveSession("blank", structuredClone(EMPTY_RESUME))
+    ).resolves.toMatchObject({
+      available: true,
+      skippedRestore: true,
+      snapshotJson: expect.any(String),
+    });
+    await expect(initializeAutosaveSession("import", importedResume)).resolves.toMatchObject({
+      available: true,
+      skippedRestore: true,
+      snapshotJson: expect.any(String),
+    });
+
+    expect(restoreAutosaveDraft).not.toHaveBeenCalled();
+    expect(saveAutosaveDraft).toHaveBeenCalledTimes(2);
+    expect(saveAutosaveDraft).toHaveBeenNthCalledWith(
+      1,
+      serializeNormalizedResume(structuredClone(EMPTY_RESUME))
+    );
+    expect(saveAutosaveDraft).toHaveBeenNthCalledWith(2, serializeNormalizedResume(importedResume));
+  });
+});

--- a/src/lib/editor/autosave-session.ts
+++ b/src/lib/editor/autosave-session.ts
@@ -1,0 +1,37 @@
+import { serializeNormalizedResume } from "@/lib/resume/normalize";
+import { restoreAutosaveDraft, saveAutosaveDraft } from "@/lib/storage/drafts";
+import type { ResumeSchema } from "@/types/resume";
+
+import type { EditorEntryMode } from "./session-entry";
+
+export interface AutosaveSessionInitResult {
+  available: boolean;
+  draft?: Awaited<ReturnType<typeof restoreAutosaveDraft>>["draft"];
+  skippedRestore?: boolean;
+  snapshotJson?: string;
+}
+
+export async function initializeAutosaveSession(
+  entryMode: EditorEntryMode,
+  currentResume: ResumeSchema
+): Promise<AutosaveSessionInitResult> {
+  if (entryMode === "restore-autosave") {
+    return restoreAutosaveDraft();
+  }
+
+  const snapshotJson = serializeNormalizedResume(currentResume);
+  const saved = await saveAutosaveDraft(snapshotJson);
+
+  if (!saved) {
+    return {
+      available: false,
+      skippedRestore: true,
+    };
+  }
+
+  return {
+    available: true,
+    skippedRestore: true,
+    snapshotJson,
+  };
+}

--- a/src/lib/editor/session-entry.test.ts
+++ b/src/lib/editor/session-entry.test.ts
@@ -1,0 +1,25 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+describe("editor entry modes", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  it("defaults to autosave restore when no explicit entry mode is queued", async () => {
+    const { consumeEditorEntryMode } = await import("./session-entry");
+
+    expect(consumeEditorEntryMode()).toBe("restore-autosave");
+  });
+
+  it("consumes one-time blank and import entry modes", async () => {
+    const { consumeEditorEntryMode, queueEditorEntryMode } = await import("./session-entry");
+
+    queueEditorEntryMode("blank");
+    expect(consumeEditorEntryMode()).toBe("blank");
+    expect(consumeEditorEntryMode()).toBe("restore-autosave");
+
+    queueEditorEntryMode("import");
+    expect(consumeEditorEntryMode()).toBe("import");
+    expect(consumeEditorEntryMode()).toBe("restore-autosave");
+  });
+});

--- a/src/lib/editor/session-entry.ts
+++ b/src/lib/editor/session-entry.ts
@@ -1,0 +1,26 @@
+export type EditorEntryMode = "restore-autosave" | "blank" | "import";
+
+const EDITOR_ENTRY_MODE_KEY = "tailory:editor-entry-mode";
+
+function isBrowser(): boolean {
+  return typeof window !== "undefined" && typeof window.sessionStorage !== "undefined";
+}
+
+export function queueEditorEntryMode(mode: Exclude<EditorEntryMode, "restore-autosave">): void {
+  if (!isBrowser()) {
+    return;
+  }
+
+  window.sessionStorage.setItem(EDITOR_ENTRY_MODE_KEY, mode);
+}
+
+export function consumeEditorEntryMode(): EditorEntryMode {
+  if (!isBrowser()) {
+    return "restore-autosave";
+  }
+
+  const queuedMode = window.sessionStorage.getItem(EDITOR_ENTRY_MODE_KEY);
+  window.sessionStorage.removeItem(EDITOR_ENTRY_MODE_KEY);
+
+  return queuedMode === "blank" || queuedMode === "import" ? queuedMode : "restore-autosave";
+}

--- a/src/pages/faq.astro
+++ b/src/pages/faq.astro
@@ -40,7 +40,7 @@ const faqs = [
   },
   {
     q: "Can I start from scratch without uploading a file?",
-    a: "Yes. The editor opens with an empty form. You can type directly into any field without uploading anything. File upload is a convenience, not a requirement.",
+    a: "Yes. Choosing start from scratch opens a blank editing session and replaces the autosave baseline for that session. Autosave restore only kicks in when you reopen the editor without explicitly starting fresh or importing a file.",
   },
   {
     q: "Is the source code available?",


### PR DESCRIPTION
## Summary
Stops autosave restore from overwriting explicit new-resume and import flows. The editor now records one-time entry modes, persists the intended blank/import snapshot as the new autosave baseline, and only restores autosave when the user reopens the editor without an explicit action.

## Changes
- add one-time editor entry mode helpers for blank and import sessions
- initialize autosave differently for explicit blank/import entry so the current snapshot replaces the old autosave instead of being overwritten by it
- reset stale import feedback on fresh/import flows and document the new start-from-scratch behavior in the FAQ

## Testing
- [x] bun run verify
- [x] bun run test -- src/lib/editor/session-entry.test.ts src/lib/editor/autosave-session.test.ts

## References
- Ticket/Issue: Fixes #49