### PR TITLE
test: add browser smoke coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,3 +36,35 @@ jobs:
 
       - name: Dependency review
         uses: actions/dependency-review-action@v4
+
+  browser-smoke:
+    name: browser-smoke
+    runs-on: ubuntu-latest
+    needs: quality
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 24
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: ".bun-version"
+          cache: true
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Install Playwright Chromium
+        run: bunx playwright install --with-deps chromium
+
+      - name: Build application
+        run: bun run build
+
+      - name: Run browser smoke suite
+        run: bun run test:smoke

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,7 @@ Thumbs.db
 # TypeScript
 *.tsbuildinfo
 .vercel
+
+# Playwright
+playwright-report/
+test-results/

--- a/README.md
+++ b/README.md
@@ -63,9 +63,11 @@ bun run lint
 bun run format:check
 bun run test
 bun run build
+bun run test:smoke
 ```
 
 Release workflow notes live in [docs/releases.md](./docs/releases.md).
+Browser smoke coverage notes live in [docs/browser-smoke.md](./docs/browser-smoke.md).
 
 ## License
 

--- a/bun.lock
+++ b/bun.lock
@@ -20,6 +20,7 @@
         "@commitlint/cli": "^20.5.3",
         "@commitlint/config-conventional": "^20.5.3",
         "@eslint/js": "^10.0.1",
+        "@playwright/test": "^1.59.1",
         "@tailwindcss/vite": "^4.2.4",
         "@testing-library/jest-dom": "^6.9.1",
         "@types/pdfmake": "^0.3.2",
@@ -351,6 +352,8 @@
     "@oslojs/encoding": ["@oslojs/encoding@1.1.0", "", {}, "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ=="],
 
     "@pkgr/core": ["@pkgr/core@0.2.9", "", {}, "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA=="],
+
+    "@playwright/test": ["@playwright/test@1.59.1", "", { "dependencies": { "playwright": "1.59.1" }, "bin": { "playwright": "cli.js" } }, "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg=="],
 
     "@polka/url": ["@polka/url@1.0.0-next.29", "", {}, "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww=="],
 
@@ -1340,6 +1343,10 @@
 
     "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
+    "playwright": ["playwright@1.59.1", "", { "dependencies": { "playwright-core": "1.59.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw=="],
+
+    "playwright-core": ["playwright-core@1.59.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg=="],
+
     "png-js": ["png-js@1.1.0", "", { "dependencies": { "browserify-zlib": "^0.2.0" } }, "sha512-PM/uYGzGdNSzqeOgly68+6wKQDL1SY0a/N+OEa/+br6LnHWOAJB0Npiamnodfq3jd2LS/i2fMeOKSAILjA+m5Q=="],
 
     "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
@@ -1785,6 +1792,8 @@
     "p-locate/p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
 
     "parse5/entities": ["entities@8.0.0", "", {}, "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA=="],
+
+    "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "safe-array-concat/isarray": ["isarray@2.0.5", "", {}, "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="],
 

--- a/docs/browser-smoke.md
+++ b/docs/browser-smoke.md
@@ -1,0 +1,25 @@
+# Browser smoke suite
+
+Tailory includes a deliberately small browser smoke suite for the highest-risk client-side flows.
+
+## What it covers
+
+- import a resume through the real browser upload flow
+- make a follow-up edit in the editor
+- trigger PDF export in-browser
+- restore the autosave draft when the editor is reopened
+
+## Why it stays small
+
+The goal is not a large end-to-end pyramid. This suite is meant to catch release-blocking regressions in the app's most fragile browser-only paths without making CI noisy or slow.
+
+## Running locally
+
+```sh
+bun run build
+bun run test:smoke
+```
+
+## CI
+
+GitHub Actions installs Chromium for Playwright and runs the smoke suite after the normal quality job passes.

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:ui": "vitest --ui",
+    "test:smoke": "playwright test",
     "verify": "bun run type-check && bun run lint && bun run format:check && bun run test && bun run build",
     "prepare": "husky"
   },
@@ -36,6 +37,7 @@
     "@commitlint/cli": "^20.5.3",
     "@commitlint/config-conventional": "^20.5.3",
     "@eslint/js": "^10.0.1",
+    "@playwright/test": "^1.59.1",
     "@tailwindcss/vite": "^4.2.4",
     "@testing-library/jest-dom": "^6.9.1",
     "@types/pdfmake": "^0.3.2",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests/smoke",
+  fullyParallel: false,
+  retries: process.env.CI ? 2 : 0,
+  reporter: "list",
+  use: {
+    baseURL: "http://127.0.0.1:4321",
+    trace: "retain-on-failure",
+  },
+  webServer: {
+    command: "bun run preview --host 127.0.0.1 --port 4321",
+    url: "http://127.0.0.1:4321",
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: {
+        ...devices["Desktop Chrome"],
+      },
+    },
+  ],
+});

--- a/tests/smoke/app.smoke.spec.ts
+++ b/tests/smoke/app.smoke.spec.ts
@@ -1,0 +1,65 @@
+import path from "node:path";
+
+import { expect, type Page, test } from "@playwright/test";
+
+const importFixturePath = path.resolve("tests/smoke/fixtures/import-resume.json");
+
+async function readAutosaveName(page: Page): Promise<string | null> {
+  return page.evaluate(async () => {
+    return await new Promise<string | null>((resolve) => {
+      const openRequest = indexedDB.open("tailory", 1);
+
+      openRequest.onerror = () => resolve(null);
+      openRequest.onsuccess = () => {
+        const db = openRequest.result;
+        const tx = db.transaction("drafts", "readonly");
+        const getRequest = tx.objectStore("drafts").get("autosave");
+
+        getRequest.onerror = () => resolve(null);
+        getRequest.onsuccess = () => {
+          const name = getRequest.result?.resumeData?.basics?.name;
+          resolve(typeof name === "string" && name.length > 0 ? name : null);
+        };
+      };
+    });
+  });
+}
+
+test("imports a resume, allows an edit, and triggers PDF export", async ({ page }) => {
+  await page.goto("/editor");
+
+  await page.getByLabel("Import resume file").setInputFiles(importFixturePath);
+
+  await expect(page.getByLabel("Full Name")).toHaveValue("Jane Smoke");
+  await expect(page.getByLabel("Professional Summary")).toHaveValue(
+    "Imported resume used by the browser smoke suite."
+  );
+
+  await page.getByLabel("Professional Summary").fill("Updated browser smoke summary.");
+  await expect(page.getByText("Updated browser smoke summary.")).toBeVisible();
+
+  const [download] = await Promise.all([
+    page.waitForEvent("download"),
+    page.getByRole("button", { name: /Export PDF/i }).click(),
+  ]);
+
+  await expect(download.suggestedFilename()).toMatch(/Jane_Smoke.*\.pdf$/u);
+});
+
+test("restores autosave when the editor is reopened", async ({ context, page }) => {
+  await page.goto("/editor");
+  await page.getByLabel("Full Name").fill("Autosave Smoke");
+
+  await expect
+    .poll(() => readAutosaveName(page), {
+      timeout: 10_000,
+      message: "expected autosave draft to be written to IndexedDB",
+    })
+    .toBe("Autosave Smoke");
+
+  const restoredPage = await context.newPage();
+  await restoredPage.goto("/editor");
+
+  await expect(restoredPage.getByLabel("Full Name")).toHaveValue("Autosave Smoke");
+  await restoredPage.close();
+});

--- a/tests/smoke/app.smoke.spec.ts
+++ b/tests/smoke/app.smoke.spec.ts
@@ -31,10 +31,9 @@ test("imports a resume, allows an edit, and triggers PDF export", async ({ page 
   await page.getByLabel("Import resume file").setInputFiles(importFixturePath);
 
   await expect(page.getByLabel("Full Name")).toHaveValue("Jane Smoke");
-  await expect(page.getByLabel("Professional Summary")).toHaveValue(
-    "Imported resume used by the browser smoke suite."
-  );
+  await expect(page.getByText("Imported resume used by the browser smoke suite.")).toBeVisible();
 
+  await page.getByRole("button", { name: "Summary" }).click();
   await page.getByLabel("Professional Summary").fill("Updated browser smoke summary.");
   await expect(page.getByText("Updated browser smoke summary.")).toBeVisible();
 

--- a/tests/smoke/fixtures/import-resume.json
+++ b/tests/smoke/fixtures/import-resume.json
@@ -1,0 +1,24 @@
+{
+  "basics": {
+    "name": "Jane Smoke",
+    "label": "Frontend Engineer",
+    "email": "jane@example.com",
+    "summary": "Imported resume used by the browser smoke suite.",
+    "url": "https://janesmoke.dev"
+  },
+  "work": [
+    {
+      "name": "Smoke Labs",
+      "position": "Engineer",
+      "startDate": "2023",
+      "endDate": "Present",
+      "summary": "Built browser-based regression coverage."
+    }
+  ],
+  "skills": [
+    {
+      "name": "TypeScript",
+      "keywords": ["testing", "playwright"]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Adds a deliberately small Playwright smoke suite for Tailory's highest-risk browser flows. The suite covers import → edit → export and autosave restore, and CI now runs it in Chromium after the normal quality job passes.

## Changes
- add Playwright-based browser smoke tests and a stable JSON import fixture
- document how to run the smoke suite locally and wire it into CI as a dedicated browser-smoke job
- add the supporting Playwright config, script, and ignored report directories

## Testing
- [x] bun run verify
- [x] bun run test:smoke -- --list
- [ ] bun run test:smoke *(requires browser runtime deps; covered in CI)*

## References
- Ticket/Issue: Fixes #56