### PR TITLE
feat: centralize editor section registry

### DIFF
--- a/src/components/editor/CommandBar.tsx
+++ b/src/components/editor/CommandBar.tsx
@@ -15,26 +15,8 @@ import {
   setImportError,
   setImportFeedback,
 } from "@/store/resume";
-import type { SectionId } from "@/types/resume";
 import DraftManager from "./DraftManager";
-
-interface Section {
-  id: SectionId;
-  label: string;
-  isDone: () => boolean;
-}
-
-const SECTIONS: Section[] = [
-  { id: "basics", label: "Basics", isDone: () => !!resume.basics.name },
-  { id: "summary", label: "Summary", isDone: () => !!resume.basics.summary },
-  { id: "work", label: "Work", isDone: () => (resume.work?.length ?? 0) > 0 },
-  { id: "education", label: "Education", isDone: () => (resume.education?.length ?? 0) > 0 },
-  { id: "skills", label: "Skills", isDone: () => (resume.skills?.length ?? 0) > 0 },
-  { id: "projects", label: "Projects", isDone: () => (resume.projects?.length ?? 0) > 0 },
-  { id: "certs", label: "Certs", isDone: () => (resume.certificates?.length ?? 0) > 0 },
-];
-
-const TOTAL = SECTIONS.length;
+import { EDITOR_SECTIONS, getSectionCompletionSummary } from "./section-registry";
 const CIRCUMFERENCE = 2 * Math.PI * 14;
 
 const CommandBar: Component = () => {
@@ -43,10 +25,12 @@ const CommandBar: Component = () => {
   const [isImporting, setIsImporting] = createSignal(false);
   let fileInputRef: HTMLInputElement | undefined;
 
-  const completedCount = () => SECTIONS.filter((s) => s.isDone()).length;
+  const completionSummary = () => getSectionCompletionSummary(resume);
+  const completedCount = () => completionSummary().completed;
+  const totalSections = () => completionSummary().total;
 
   const ringDash = () => {
-    const filled = (completedCount() / TOTAL) * CIRCUMFERENCE;
+    const filled = (completedCount() / totalSections()) * CIRCUMFERENCE;
     return `${filled} ${CIRCUMFERENCE - filled}`;
   };
 
@@ -151,7 +135,7 @@ const CommandBar: Component = () => {
       {/* Completion ring */}
       <div
         class="hidden shrink-0 items-center gap-1.5 md:flex"
-        aria-label={`${completedCount()} of ${TOTAL} sections complete`}
+        aria-label={`${completedCount()} of ${totalSections()} sections complete`}
       >
         <svg width="32" height="32" viewBox="0 0 32 32" aria-hidden="true">
           <circle
@@ -184,7 +168,7 @@ const CommandBar: Component = () => {
             font-family="'DM Sans', sans-serif"
             font-weight="600"
           >
-            {completedCount()}/{TOTAL}
+            {completedCount()}/{totalSections()}
           </text>
         </svg>
       </div>
@@ -192,7 +176,7 @@ const CommandBar: Component = () => {
       {/* Section chips */}
       <nav class="hidden md:flex md:flex-1 md:items-center md:gap-1.5" aria-label="Resume sections">
         <div class="flex items-center gap-1.5">
-          <For each={SECTIONS}>
+          <For each={EDITOR_SECTIONS}>
             {(section) => (
               <button
                 type="button"
@@ -208,8 +192,10 @@ const CommandBar: Component = () => {
                       : "1px solid rgba(255,255,255,0.12)",
                 }}
               >
-                <span aria-hidden="true">{section.isDone() ? "✓" : "○"}</span>
-                {section.label}
+                <span aria-hidden="true">
+                  {completionSummary().completedSectionIds.includes(section.id) ? "✓" : "○"}
+                </span>
+                {section.navLabel}
               </button>
             )}
           </For>

--- a/src/components/editor/EditorShell.tsx
+++ b/src/components/editor/EditorShell.tsx
@@ -1,76 +1,17 @@
-import { type Component, type JSX, Show } from "solid-js";
+import { type Component, Show } from "solid-js";
 import { Transition } from "solid-transition-group";
 
 import { activeSection, setActiveSection } from "@/store/resume";
-import type { SectionId } from "@/types/resume";
-import BasicsForm from "./BasicsForm";
-import CertificatesForm from "./CertificatesForm";
-import EducationForm from "./EducationForm";
-import ProjectsForm from "./ProjectsForm";
-import SkillsForm from "./SkillsForm";
-import SummaryForm from "./SummaryForm";
-import WorkForm from "./WorkForm";
-
-interface SectionMeta {
-  component: () => JSX.Element;
-  id: SectionId;
-  label: string;
-  subtitle: string;
-}
-
-const SECTIONS: SectionMeta[] = [
-  {
-    id: "basics",
-    label: "Basic Info",
-    subtitle: "Name, contact details, and headline",
-    component: () => <BasicsForm />,
-  },
-  {
-    id: "summary",
-    label: "Summary",
-    subtitle: "A brief professional overview",
-    component: () => <SummaryForm />,
-  },
-  {
-    id: "work",
-    label: "Work Experience",
-    subtitle: "Jobs, roles, and accomplishments",
-    component: () => <WorkForm />,
-  },
-  {
-    id: "education",
-    label: "Education",
-    subtitle: "Degrees, institutions, and dates",
-    component: () => <EducationForm />,
-  },
-  {
-    id: "skills",
-    label: "Skills",
-    subtitle: "Technical and professional skills",
-    component: () => <SkillsForm />,
-  },
-  {
-    id: "projects",
-    label: "Projects",
-    subtitle: "Personal and professional projects",
-    component: () => <ProjectsForm />,
-  },
-  {
-    id: "certs",
-    label: "Certifications",
-    subtitle: "Licenses, certificates, and credentials",
-    component: () => <CertificatesForm />,
-  },
-];
+import { EDITOR_SECTIONS, getEditorSectionDefinition } from "./section-registry";
 
 // ── EditorShell ──────────────────────────────────────────────────────────────
 
 const EditorShell: Component = () => {
-  const currentSection = () => SECTIONS.find((s) => s.id === activeSection());
-  const currentIndex = () => SECTIONS.findIndex((s) => s.id === activeSection());
-  const prevSection = () => (currentIndex() > 0 ? SECTIONS[currentIndex() - 1] : null);
+  const currentSection = () => getEditorSectionDefinition(activeSection());
+  const currentIndex = () => EDITOR_SECTIONS.findIndex((section) => section.id === activeSection());
+  const prevSection = () => (currentIndex() > 0 ? EDITOR_SECTIONS[currentIndex() - 1] : null);
   const nextSection = () =>
-    currentIndex() < SECTIONS.length - 1 ? SECTIONS[currentIndex() + 1] : null;
+    currentIndex() < EDITOR_SECTIONS.length - 1 ? EDITOR_SECTIONS[currentIndex() + 1] : null;
 
   return (
     <div class="flex h-full flex-col" style={{ background: "#f4f8f5" }}>
@@ -118,7 +59,7 @@ const EditorShell: Component = () => {
               </svg>
             </button>
             <span class="min-w-[3rem] text-center text-xs font-medium" style={{ color: "#5a7a68" }}>
-              {currentIndex() + 1}/{SECTIONS.length}
+              {currentIndex() + 1}/{EDITOR_SECTIONS.length}
             </span>
             <button
               type="button"

--- a/src/components/editor/section-registry.test.tsx
+++ b/src/components/editor/section-registry.test.tsx
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+
+import { EMPTY_RESUME, type ResumeSchema } from "@/types/resume";
+
+import {
+  COMPLETION_SECTIONS,
+  EDITOR_SECTIONS,
+  getSectionCompletionSummary,
+} from "./section-registry";
+
+type DeepPartial<T> = {
+  [K in keyof T]?: T[K] extends Array<infer U>
+    ? DeepPartial<U>[]
+    : T[K] extends object
+      ? DeepPartial<T[K]>
+      : T[K];
+};
+
+function createResume(overrides?: DeepPartial<ResumeSchema>): ResumeSchema {
+  return {
+    ...structuredClone(EMPTY_RESUME),
+    ...overrides,
+    basics: {
+      ...structuredClone(EMPTY_RESUME.basics),
+      ...overrides?.basics,
+      location: {
+        ...structuredClone(EMPTY_RESUME.basics.location ?? {}),
+        ...overrides?.basics?.location,
+      },
+    },
+  };
+}
+
+describe("editor section registry", () => {
+  it("derives editable navigation from a shared registry", () => {
+    expect(EDITOR_SECTIONS.map((section) => section.id)).toEqual([
+      "basics",
+      "summary",
+      "work",
+      "education",
+      "skills",
+      "projects",
+      "certificates",
+    ]);
+  });
+
+  it("counts all render-supported sections in completion metrics", () => {
+    const summary = getSectionCompletionSummary(
+      createResume({
+        basics: { name: "Jane Doe", summary: "Frontend engineer" },
+        work: [{ id: "work-1", name: "Acme", position: "Engineer" }],
+        volunteer: [{ id: "vol-1", organization: "Code Club", position: "Mentor" }],
+      })
+    );
+
+    expect(summary.total).toBe(COMPLETION_SECTIONS.length);
+    expect(summary.completed).toBe(4);
+    expect(summary.completedSectionIds).toEqual(["basics", "summary", "work", "volunteer"]);
+  });
+});

--- a/src/components/editor/section-registry.tsx
+++ b/src/components/editor/section-registry.tsx
@@ -1,0 +1,165 @@
+import type { JSX } from "solid-js";
+
+import type { EditorSectionId, ResumeSchema, SupportedSectionId } from "@/types/resume";
+import BasicsForm from "./BasicsForm";
+import CertificatesForm from "./CertificatesForm";
+import EducationForm from "./EducationForm";
+import ProjectsForm from "./ProjectsForm";
+import SkillsForm from "./SkillsForm";
+import SummaryForm from "./SummaryForm";
+import WorkForm from "./WorkForm";
+
+export interface ResumeSectionDefinition {
+  component?: () => JSX.Element;
+  id: SupportedSectionId;
+  isComplete: (resume: ResumeSchema) => boolean;
+  label: string;
+  navLabel: string;
+  subtitle: string;
+}
+
+export interface EditableResumeSectionDefinition extends ResumeSectionDefinition {
+  component: () => JSX.Element;
+  id: EditorSectionId;
+}
+
+export const SECTION_REGISTRY: ResumeSectionDefinition[] = [
+  {
+    id: "basics",
+    label: "Basic Info",
+    navLabel: "Basics",
+    subtitle: "Name, contact details, and headline",
+    component: () => <BasicsForm />,
+    isComplete: (resume) => !!resume.basics.name,
+  },
+  {
+    id: "summary",
+    label: "Summary",
+    navLabel: "Summary",
+    subtitle: "A brief professional overview",
+    component: () => <SummaryForm />,
+    isComplete: (resume) => !!resume.basics.summary,
+  },
+  {
+    id: "work",
+    label: "Work Experience",
+    navLabel: "Work",
+    subtitle: "Jobs, roles, and accomplishments",
+    component: () => <WorkForm />,
+    isComplete: (resume) => (resume.work?.length ?? 0) > 0,
+  },
+  {
+    id: "volunteer",
+    label: "Volunteer",
+    navLabel: "Volunteer",
+    subtitle: "Community work, service, and contributions",
+    component: undefined,
+    isComplete: (resume) => (resume.volunteer?.length ?? 0) > 0,
+  },
+  {
+    id: "education",
+    label: "Education",
+    navLabel: "Education",
+    subtitle: "Degrees, institutions, and dates",
+    component: () => <EducationForm />,
+    isComplete: (resume) => (resume.education?.length ?? 0) > 0,
+  },
+  {
+    id: "awards",
+    label: "Awards",
+    navLabel: "Awards",
+    subtitle: "Honors, recognition, and distinctions",
+    component: undefined,
+    isComplete: (resume) => (resume.awards?.length ?? 0) > 0,
+  },
+  {
+    id: "publications",
+    label: "Publications",
+    navLabel: "Publications",
+    subtitle: "Articles, papers, talks, and published work",
+    component: undefined,
+    isComplete: (resume) => (resume.publications?.length ?? 0) > 0,
+  },
+  {
+    id: "skills",
+    label: "Skills",
+    navLabel: "Skills",
+    subtitle: "Technical and professional skills",
+    component: () => <SkillsForm />,
+    isComplete: (resume) => (resume.skills?.length ?? 0) > 0,
+  },
+  {
+    id: "languages",
+    label: "Languages",
+    navLabel: "Languages",
+    subtitle: "Languages and fluency levels",
+    component: undefined,
+    isComplete: (resume) => (resume.languages?.length ?? 0) > 0,
+  },
+  {
+    id: "interests",
+    label: "Interests",
+    navLabel: "Interests",
+    subtitle: "Communities, hobbies, and focus areas",
+    component: undefined,
+    isComplete: (resume) => (resume.interests?.length ?? 0) > 0,
+  },
+  {
+    id: "projects",
+    label: "Projects",
+    navLabel: "Projects",
+    subtitle: "Personal and professional projects",
+    component: () => <ProjectsForm />,
+    isComplete: (resume) => (resume.projects?.length ?? 0) > 0,
+  },
+  {
+    id: "references",
+    label: "References",
+    navLabel: "References",
+    subtitle: "People who can vouch for your work",
+    component: undefined,
+    isComplete: (resume) => (resume.references?.length ?? 0) > 0,
+  },
+  {
+    id: "certificates",
+    label: "Certifications",
+    navLabel: "Certs",
+    subtitle: "Licenses, certificates, and credentials",
+    component: () => <CertificatesForm />,
+    isComplete: (resume) => (resume.certificates?.length ?? 0) > 0,
+  },
+];
+
+export const COMPLETION_SECTIONS = SECTION_REGISTRY;
+
+export const EDITOR_SECTIONS = SECTION_REGISTRY.filter(
+  (section): section is EditableResumeSectionDefinition => typeof section.component === "function"
+);
+
+export function getSectionDefinition(id: SupportedSectionId): ResumeSectionDefinition | undefined {
+  return SECTION_REGISTRY.find((section) => section.id === id);
+}
+
+export function getEditorSectionDefinition(
+  id: EditorSectionId
+): EditableResumeSectionDefinition | undefined {
+  return EDITOR_SECTIONS.find((section) => section.id === id);
+}
+
+export function getSectionCompletionSummary(resume: ResumeSchema): {
+  completed: number;
+  completedSectionIds: SupportedSectionId[];
+  total: number;
+} {
+  const completedSections = COMPLETION_SECTIONS.filter((section) => section.isComplete(resume));
+
+  return {
+    completed: completedSections.length,
+    completedSectionIds: completedSections.map((section) => section.id),
+    total: COMPLETION_SECTIONS.length,
+  };
+}
+
+export function isResumeVisuallyEmpty(resume: ResumeSchema): boolean {
+  return getSectionCompletionSummary(resume).completed === 0;
+}

--- a/src/components/preview/ResumePreview.tsx
+++ b/src/components/preview/ResumePreview.tsx
@@ -1,22 +1,15 @@
 import { type Component, For, Show } from "solid-js";
 
-import { TEMPLATE_OPTIONS } from "@/lib/templates/registry";
 import ResumeDocument from "@/components/resume/ResumeDocument";
 import { resolveResumeDesignSettings } from "@/lib/resume/design";
-import { resume, selectedTemplate, setSelectedTemplate } from "@/store/resume";
-import { selectedAccentColor } from "@/store/resume";
+import { TEMPLATE_OPTIONS } from "@/lib/templates/registry";
+import { resume, selectedAccentColor, selectedTemplate, setSelectedTemplate } from "@/store/resume";
+import {
+  getSectionCompletionSummary,
+  isResumeVisuallyEmpty,
+} from "@/components/editor/section-registry";
 
-const TOTAL_SECTIONS = 7;
 const CIRCUMFERENCE = 2 * Math.PI * 14;
-
-const isEmpty = () =>
-  !resume.basics.name &&
-  !resume.basics.summary &&
-  (resume.work?.length ?? 0) === 0 &&
-  (resume.education?.length ?? 0) === 0 &&
-  (resume.skills?.length ?? 0) === 0 &&
-  (resume.projects?.length ?? 0) === 0 &&
-  (resume.certificates?.length ?? 0) === 0;
 
 const ResumePreview: Component = () => {
   const design = () =>
@@ -25,20 +18,11 @@ const ResumePreview: Component = () => {
       accentColor: selectedAccentColor(),
     });
 
-  const completedCount = () => {
-    let count = 0;
-    if (resume.basics.name) count++;
-    if (resume.basics.summary) count++;
-    if ((resume.work?.length ?? 0) > 0) count++;
-    if ((resume.education?.length ?? 0) > 0) count++;
-    if ((resume.skills?.length ?? 0) > 0) count++;
-    if ((resume.projects?.length ?? 0) > 0) count++;
-    if ((resume.certificates?.length ?? 0) > 0) count++;
-    return count;
-  };
+  const completionSummary = () => getSectionCompletionSummary(resume);
+  const completedCount = () => completionSummary().completed;
 
   const ringDash = () => {
-    const filled = (completedCount() / TOTAL_SECTIONS) * CIRCUMFERENCE;
+    const filled = (completedCount() / completionSummary().total) * CIRCUMFERENCE;
     return `${filled} ${CIRCUMFERENCE - filled}`;
   };
 
@@ -52,7 +36,7 @@ const ResumePreview: Component = () => {
         {/* Completeness ring */}
         <div
           class="flex items-center gap-2"
-          aria-label={`${completedCount()} of ${TOTAL_SECTIONS} sections complete`}
+          aria-label={`${completedCount()} of ${completionSummary().total} sections complete`}
         >
           <svg width="32" height="32" viewBox="0 0 32 32" aria-hidden="true">
             <circle cx="16" cy="16" r="14" fill="none" stroke="#ccddd4" stroke-width="3" />
@@ -77,7 +61,7 @@ const ResumePreview: Component = () => {
               font-family="'DM Sans', sans-serif"
               font-weight="600"
             >
-              {completedCount()}/{TOTAL_SECTIONS}
+              {completedCount()}/{completionSummary().total}
             </text>
           </svg>
           <span class="text-xs" style={{ color: "#5a7a68" }}>
@@ -113,7 +97,7 @@ const ResumePreview: Component = () => {
 
       {/* Preview area */}
       <Show
-        when={!isEmpty()}
+        when={!isResumeVisuallyEmpty(resume)}
         fallback={
           <div class="flex flex-1 items-center justify-center p-8">
             <div class="max-w-xs text-center">

--- a/src/store/resume.ts
+++ b/src/store/resume.ts
@@ -5,7 +5,7 @@ import { DEFAULT_RESUME_ACCENT_COLOR } from "@/lib/resume/design";
 import { normalizeResume } from "@/lib/resume/normalize";
 import { DEFAULT_TEMPLATE_ID, type TemplateId } from "@/types/template";
 import { EMPTY_RESUME } from "@/types/resume";
-import type { ResumeSchema, SectionId } from "@/types/resume";
+import type { EditorSectionId, ResumeSchema } from "@/types/resume";
 
 // Deep clone to avoid sharing the same reference
 const defaultResume: ResumeSchema = JSON.parse(JSON.stringify(EMPTY_RESUME));
@@ -19,7 +19,7 @@ export const [selectedAccentColor, setSelectedAccentColor] = createSignal(
   DEFAULT_RESUME_ACCENT_COLOR
 );
 
-export const [activeSection, setActiveSection] = createSignal<SectionId>("basics");
+export const [activeSection, setActiveSection] = createSignal<EditorSectionId>("basics");
 
 export interface ImportFeedback {
   confidence: number;

--- a/src/types/resume.ts
+++ b/src/types/resume.ts
@@ -142,14 +142,25 @@ export interface ResumeSchema {
   projects?: ResumeProject[];
 }
 
-export type SectionId =
+export type EditorSectionId =
   | "basics"
   | "summary"
   | "work"
   | "education"
   | "skills"
   | "projects"
-  | "certs";
+  | "certificates";
+
+export type SupportedSectionId =
+  | EditorSectionId
+  | "volunteer"
+  | "awards"
+  | "publications"
+  | "languages"
+  | "interests"
+  | "references";
+
+export type SectionId = EditorSectionId;
 
 export const EMPTY_RESUME: ResumeSchema = {
   basics: {


### PR DESCRIPTION
## Summary
Moves editor navigation metadata and completion logic into a shared registry so the command bar, editor shell, and preview completeness UI all derive from the same source of truth. Completion metrics now include every section Tailory can currently render/export, not just the sections with form chips today.

## Changes
- add a shared section registry with labels, subtitles, completion rules, and current editor registration state
- refactor the command bar, editor shell, and preview completeness UI to read from that registry instead of separate hard-coded lists
- add focused tests for editable section order and completion metrics across render-supported sections

## Testing
- [x] bun run verify
- [x] bun run test -- src/components/editor/section-registry.test.tsx

## References
- Ticket/Issue: Fixes #52