### PR TITLE
fix: complete inline editor validation

### DIFF
--- a/src/components/editor/BasicsForm.tsx
+++ b/src/components/editor/BasicsForm.tsx
@@ -1,5 +1,6 @@
 import { type Component, createSignal } from "solid-js";
 
+import { validateOptionalPhone, validateRequiredName } from "@/lib/editor/validation";
 import FormField from "@/components/ui/FormField";
 import Input from "@/components/ui/Input";
 import { resume, setResume } from "@/store/resume";
@@ -24,16 +25,24 @@ function validateUrl(value: string): string {
 }
 
 const BasicsForm: Component = () => {
+  const [nameError, setNameError] = createSignal("");
   const [emailError, setEmailError] = createSignal("");
+  const [phoneError, setPhoneError] = createSignal("");
   const [urlError, setUrlError] = createSignal("");
 
   return (
     <div class="space-y-4">
-      <FormField label="Full Name" id="basics-name" required>
+      <FormField label="Full Name" id="basics-name" required error={nameError()}>
         <Input
           id="basics-name"
           value={resume.basics.name}
-          onInput={(v) => setResume("basics", "name", v)}
+          onInput={(v) => {
+            setResume("basics", "name", v);
+            if (nameError()) setNameError(validateRequiredName(v));
+          }}
+          onBlur={() => setNameError(validateRequiredName(resume.basics.name))}
+          error={!!nameError()}
+          aria-describedby={nameError() ? "basics-name-error" : undefined}
           placeholder="Jane Doe"
         />
       </FormField>
@@ -64,12 +73,18 @@ const BasicsForm: Component = () => {
           />
         </FormField>
 
-        <FormField label="Phone" id="basics-phone">
+        <FormField label="Phone" id="basics-phone" error={phoneError()}>
           <Input
             id="basics-phone"
             type="tel"
             value={resume.basics.phone ?? ""}
-            onInput={(v) => setResume("basics", "phone", v)}
+            onInput={(v) => {
+              setResume("basics", "phone", v);
+              if (phoneError()) setPhoneError(validateOptionalPhone(v));
+            }}
+            onBlur={() => setPhoneError(validateOptionalPhone(resume.basics.phone ?? ""))}
+            error={!!phoneError()}
+            aria-describedby={phoneError() ? "basics-phone-error" : undefined}
             placeholder="+1 555-123-4567"
           />
         </FormField>

--- a/src/components/editor/EducationForm.tsx
+++ b/src/components/editor/EducationForm.tsx
@@ -1,9 +1,11 @@
-import type { Component } from "solid-js";
-import { resume, setResume } from "@/store/resume";
-import type { ResumeEducation } from "@/types/resume";
-import { ReorderableList } from "@/components/ui/ReorderableList";
+import { type Component, createSignal } from "solid-js";
+
+import { validateChronologicalDateRange } from "@/lib/editor/validation";
 import FormField from "@/components/ui/FormField";
 import Input from "@/components/ui/Input";
+import { ReorderableList } from "@/components/ui/ReorderableList";
+import { resume, setResume } from "@/store/resume";
+import type { ResumeEducation } from "@/types/resume";
 
 function newEducation(): ResumeEducation {
   return {
@@ -17,12 +19,33 @@ function newEducation(): ResumeEducation {
 }
 
 const EducationForm: Component = () => {
+  const [dateErrors, setDateErrors] = createSignal<Record<string, string>>({});
+
+  const validateDates = (id: string) => {
+    const item = resume.education?.find((education) => education.id === id);
+    const error = item ? validateChronologicalDateRange(item.startDate, item.endDate) : "";
+
+    setDateErrors((current) => ({
+      ...current,
+      [id]: error,
+    }));
+  };
+
+  const clearDateError = (id: string) => {
+    setDateErrors((current) => {
+      const next = { ...current };
+      delete next[id];
+      return next;
+    });
+  };
+
   const addEntry = () => {
     setResume("education", (e) => [...(e ?? []), newEducation()]);
   };
 
   const removeEntry = (id: string) => {
     setResume("education", (e) => (e ?? []).filter((edu) => edu.id !== id));
+    clearDateError(id);
   };
 
   const reorder = (items: ResumeEducation[]) => {
@@ -35,6 +58,10 @@ const EducationForm: Component = () => {
     value: ResumeEducation[K]
   ) => {
     setResume("education", (e) => e?.id === id, field, value);
+
+    if ((field === "startDate" || field === "endDate") && dateErrors()[id]) {
+      validateDates(id);
+    }
   };
 
   return (
@@ -80,14 +107,19 @@ const EducationForm: Component = () => {
                 id={`edu-start-${item.id}`}
                 value={item.startDate ?? ""}
                 onInput={(v) => updateField(item.id, "startDate", v)}
+                onBlur={() => validateDates(item.id)}
+                error={!!dateErrors()[item.id]}
                 placeholder="2018"
               />
             </FormField>
-            <FormField label="End Date" id={`edu-end-${item.id}`}>
+            <FormField label="End Date" id={`edu-end-${item.id}`} error={dateErrors()[item.id]}>
               <Input
                 id={`edu-end-${item.id}`}
                 value={item.endDate ?? ""}
                 onInput={(v) => updateField(item.id, "endDate", v)}
+                onBlur={() => validateDates(item.id)}
+                error={!!dateErrors()[item.id]}
+                aria-describedby={dateErrors()[item.id] ? `edu-end-${item.id}-error` : undefined}
                 placeholder="2022"
               />
             </FormField>

--- a/src/components/editor/WorkForm.tsx
+++ b/src/components/editor/WorkForm.tsx
@@ -1,6 +1,7 @@
-import { type Component, For } from "solid-js";
+import { type Component, createSignal, For } from "solid-js";
 import { produce } from "solid-js/store";
 
+import { validateChronologicalDateRange } from "@/lib/editor/validation";
 import FormField from "@/components/ui/FormField";
 import Input from "@/components/ui/Input";
 import { ReorderableList } from "@/components/ui/ReorderableList";
@@ -20,12 +21,33 @@ function newWork(): ResumeWork {
 }
 
 const WorkForm: Component = () => {
+  const [dateErrors, setDateErrors] = createSignal<Record<string, string>>({});
+
+  const validateDates = (id: string) => {
+    const item = resume.work?.find((work) => work.id === id);
+    const error = item ? validateChronologicalDateRange(item.startDate, item.endDate) : "";
+
+    setDateErrors((current) => ({
+      ...current,
+      [id]: error,
+    }));
+  };
+
+  const clearDateError = (id: string) => {
+    setDateErrors((current) => {
+      const next = { ...current };
+      delete next[id];
+      return next;
+    });
+  };
+
   const addEntry = () => {
     setResume("work", (w) => [...(w ?? []), newWork()]);
   };
 
   const removeEntry = (id: string) => {
     setResume("work", (w) => (w ?? []).filter((e) => e.id !== id));
+    clearDateError(id);
   };
 
   const reorder = (items: ResumeWork[]) => {
@@ -34,6 +56,10 @@ const WorkForm: Component = () => {
 
   const updateField = <K extends keyof ResumeWork>(id: string, field: K, value: ResumeWork[K]) => {
     setResume("work", (w) => w?.id === id, field, value);
+
+    if ((field === "startDate" || field === "endDate") && dateErrors()[id]) {
+      validateDates(id);
+    }
   };
 
   const addHighlight = (id: string) => {
@@ -95,14 +121,19 @@ const WorkForm: Component = () => {
                 id={`work-start-${item.id}`}
                 value={item.startDate ?? ""}
                 onInput={(v) => updateField(item.id, "startDate", v)}
+                onBlur={() => validateDates(item.id)}
+                error={!!dateErrors()[item.id]}
                 placeholder="Jan 2021"
               />
             </FormField>
-            <FormField label="End Date" id={`work-end-${item.id}`}>
+            <FormField label="End Date" id={`work-end-${item.id}`} error={dateErrors()[item.id]}>
               <Input
                 id={`work-end-${item.id}`}
                 value={item.endDate ?? ""}
                 onInput={(v) => updateField(item.id, "endDate", v)}
+                onBlur={() => validateDates(item.id)}
+                error={!!dateErrors()[item.id]}
+                aria-describedby={dateErrors()[item.id] ? `work-end-${item.id}-error` : undefined}
                 placeholder="Present"
               />
             </FormField>

--- a/src/lib/editor/validation.test.ts
+++ b/src/lib/editor/validation.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  compareResumeDates,
+  validateChronologicalDateRange,
+  validateOptionalPhone,
+  validateRequiredName,
+} from "./validation";
+
+describe("editor validation helpers", () => {
+  it("accepts empty optional phone values and common real-world phone formats", () => {
+    expect(validateOptionalPhone("")).toBe("");
+    expect(validateOptionalPhone("+1 (555) 123-4567")).toBe("");
+    expect(validateOptionalPhone("+44 20 7946 0958")).toBe("");
+    expect(validateOptionalPhone("5551234567")).toBe("");
+  });
+
+  it("rejects phone values that do not resemble phone numbers", () => {
+    expect(validateOptionalPhone("abc")).toBe("Enter a valid phone number.");
+    expect(validateOptionalPhone("12-34")).toBe("Enter a valid phone number.");
+  });
+
+  it("requires a non-empty basics name once the field is touched", () => {
+    expect(validateRequiredName("")).toBe("Enter your name.");
+    expect(validateRequiredName("  Jane Doe ")).toBe("");
+  });
+
+  it("parses supported resume date formats for chronological comparison", () => {
+    expect(compareResumeDates("2022", "2021")).toBeGreaterThan(0);
+    expect(compareResumeDates("Feb 2022", "2022")).toBeGreaterThan(0);
+    expect(compareResumeDates("present", "Jan 2024")).toBeGreaterThan(0);
+    expect(compareResumeDates("Apr 2020", "Apr 2020")).toBe(0);
+  });
+
+  it("validates work and education ranges only when both dates are comparable", () => {
+    expect(validateChronologicalDateRange("2020", "2022")).toBe("");
+    expect(validateChronologicalDateRange("Jan 2024", "Present")).toBe("");
+    expect(validateChronologicalDateRange("", "Present")).toBe("");
+    expect(validateChronologicalDateRange("Soon", "Later")).toBe("");
+    expect(validateChronologicalDateRange("2024", "2021")).toBe(
+      "End date must be the same as or later than the start date."
+    );
+    expect(validateChronologicalDateRange("Mar 2024", "Feb 2024")).toBe(
+      "End date must be the same as or later than the start date."
+    );
+  });
+});

--- a/src/lib/editor/validation.ts
+++ b/src/lib/editor/validation.ts
@@ -1,0 +1,96 @@
+const PHONE_ALLOWED_RE = /^[+()\-\s\d./]+$/u;
+const MONTH_YEAR_RE = /^(jan|feb|mar|apr|may|jun|jul|aug|sep|sept|oct|nov|dec)\s+(\d{4})$/iu;
+const YEAR_RE = /^\d{4}$/u;
+const PRESENT_RE = /^(present|current|now)$/iu;
+
+const MONTH_INDEX: Record<string, number> = {
+  jan: 0,
+  feb: 1,
+  mar: 2,
+  apr: 3,
+  may: 4,
+  jun: 5,
+  jul: 6,
+  aug: 7,
+  sep: 8,
+  sept: 8,
+  oct: 9,
+  nov: 10,
+  dec: 11,
+};
+
+function normalizeWhitespace(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+function toComparableResumeDate(value: string): number | null {
+  const normalized = normalizeWhitespace(value);
+
+  if (!normalized) {
+    return null;
+  }
+
+  if (PRESENT_RE.test(normalized)) {
+    return Number.POSITIVE_INFINITY;
+  }
+
+  if (YEAR_RE.test(normalized)) {
+    return Number.parseInt(normalized, 10) * 12;
+  }
+
+  const match = normalized.match(MONTH_YEAR_RE);
+  if (!match) {
+    return null;
+  }
+
+  const month = MONTH_INDEX[match[1]?.toLowerCase() ?? ""];
+  const year = Number.parseInt(match[2] ?? "", 10);
+
+  if (month === undefined || Number.isNaN(year)) {
+    return null;
+  }
+
+  return year * 12 + month;
+}
+
+export function validateRequiredName(value: string): string {
+  return normalizeWhitespace(value) ? "" : "Enter your name.";
+}
+
+export function validateOptionalPhone(value: string): string {
+  const normalized = normalizeWhitespace(value);
+
+  if (!normalized) {
+    return "";
+  }
+
+  const digits = normalized.replace(/\D/g, "");
+
+  if (!PHONE_ALLOWED_RE.test(normalized) || digits.length < 7) {
+    return "Enter a valid phone number.";
+  }
+
+  return "";
+}
+
+export function compareResumeDates(left: string, right: string): number {
+  const leftValue = toComparableResumeDate(left);
+  const rightValue = toComparableResumeDate(right);
+
+  if (leftValue === null || rightValue === null) {
+    return 0;
+  }
+
+  return leftValue - rightValue;
+}
+
+export function validateChronologicalDateRange(startDate?: string, endDate?: string): string {
+  const startValue = startDate ? toComparableResumeDate(startDate) : null;
+  const endValue = endDate ? toComparableResumeDate(endDate) : null;
+
+  if (startValue === null || endValue === null) {
+    return "";
+  }
+
+  return startValue <= endValue ? "" : "End date must be the same as or later than the start date.";
+}


### PR DESCRIPTION
## Summary
Completes the inline validation pass across the editor by adding required-name, optional phone, and chronological date-range validation. Errors stay quiet until fields are blurred, then update live while the user fixes them.

## Changes
- add shared validation helpers for required name, optional phone numbers, and supported resume date formats
- show inline name and phone feedback in BasicsForm using the existing touched-on-blur pattern
- validate work and education start/end ranges for year, month-year, and Present-style values

## Testing
- [x] bun run verify
- [x] bun run test -- src/lib/editor/validation.test.ts

## References
- Ticket/Issue: Fixes #10