### PR TITLE
feat: add persistent import review card

### DIFF
--- a/src/components/editor/CommandBar.tsx
+++ b/src/components/editor/CommandBar.tsx
@@ -6,6 +6,7 @@ import { importResumeFile } from "@/lib/upload/import-resume";
 import { validateUploadFile } from "@/lib/upload/guardrails";
 import {
   activeSection,
+  clearImportReview,
   loadResume,
   resume,
   selectedAccentColor,
@@ -13,7 +14,7 @@ import {
   setActiveSection,
   setExportError,
   setImportError,
-  setImportFeedback,
+  showImportReview,
 } from "@/store/resume";
 import type { SectionId } from "@/types/resume";
 import DraftManager from "./DraftManager";
@@ -97,7 +98,9 @@ const CommandBar: Component = () => {
     }
 
     if (outcome.feedback) {
-      setImportFeedback(outcome.feedback);
+      showImportReview(outcome.feedback);
+    } else {
+      clearImportReview();
     }
     loadResume(outcome.resume);
   };

--- a/src/components/editor/DraftManager.tsx
+++ b/src/components/editor/DraftManager.tsx
@@ -17,7 +17,7 @@ import {
 } from "@/lib/storage/db";
 import { serializeNormalizedResume } from "@/lib/resume/normalize";
 import { cloneResumeData, restoreAutosaveDraft, saveAutosaveDraft } from "@/lib/storage/drafts";
-import { loadResume, resume } from "@/store/resume";
+import { clearImportReview, loadResume, resume } from "@/store/resume";
 
 type Status = "idle" | "saving" | "saved" | "error";
 
@@ -61,6 +61,7 @@ const DraftManager: Component<DraftManagerProps> = (props) => {
 
     if (restored.draft) {
       setLastAutosaveSnapshot(restored.snapshotJson);
+      clearImportReview();
       loadResume(restored.draft.resumeData);
     }
 
@@ -131,6 +132,7 @@ const DraftManager: Component<DraftManagerProps> = (props) => {
   };
 
   const loadDraft = (draft: ResumeDraft) => {
+    clearImportReview();
     loadResume(draft.resumeData);
     setShowList(false);
   };

--- a/src/components/editor/EditorLayout.tsx
+++ b/src/components/editor/EditorLayout.tsx
@@ -3,38 +3,19 @@ import { createEffect, createSignal, onCleanup, onMount, Show } from "solid-js";
 import EditorShell from "@/components/editor/EditorShell";
 import ErrorBoundary from "@/components/ui/ErrorBoundary";
 import ResumePreview from "@/components/preview/ResumePreview";
+import { formatImportReviewCounts, getImportConfidenceState } from "@/lib/editor/import-review";
 import {
+  dismissImportReview,
   exportError,
   importError,
-  importFeedback,
+  importReview,
   setExportError,
   setImportError,
-  setImportFeedback,
 } from "@/store/resume";
 
 type Pane = "editor" | "preview";
 
 const MOBILE_BREAKPOINT = 768;
-
-// ── Confidence helpers ────────────────────────────────────────────────────────
-
-function confidenceLabel(score: number): string {
-  if (score >= 0.8) return "High confidence";
-  if (score >= 0.5) return "Medium confidence";
-  return "Low confidence — review carefully";
-}
-
-function confidenceAccent(score: number): string {
-  if (score >= 0.8) return "#1d6648";
-  if (score >= 0.5) return "#b45309";
-  return "#b91c1c";
-}
-
-function confidenceBorder(score: number): string {
-  if (score >= 0.8) return "#ccddd4";
-  if (score >= 0.5) return "#fcd34d";
-  return "#fca5a5";
-}
 
 // ── Toast components ──────────────────────────────────────────────────────────
 
@@ -156,80 +137,6 @@ function ImportErrorToast() {
   );
 }
 
-function ImportSuccessToast() {
-  createEffect(() => {
-    const fb = importFeedback();
-    if (!fb) return;
-    const timer = setTimeout(() => setImportFeedback(null), 5000);
-    onCleanup(() => clearTimeout(timer));
-  });
-
-  return (
-    <Show when={importFeedback()}>
-      {(_) => {
-        const fb = importFeedback()!;
-        const parts: string[] = [];
-        if (fb.work > 0) parts.push(`${fb.work} job${fb.work > 1 ? "s" : ""}`);
-        if (fb.education > 0) parts.push(`${fb.education} degree${fb.education > 1 ? "s" : ""}`);
-        if (fb.skills > 0) parts.push(`${fb.skills} skill${fb.skills > 1 ? "s" : ""}`);
-        if (fb.projects > 0) parts.push(`${fb.projects} project${fb.projects > 1 ? "s" : ""}`);
-        if (fb.certificates > 0)
-          parts.push(`${fb.certificates} cert${fb.certificates > 1 ? "s" : ""}`);
-
-        return (
-          <div
-            role="status"
-            aria-live="polite"
-            class="flex w-full items-start gap-3 rounded-lg border bg-white px-4 py-3 shadow-xl shadow-black/10"
-            style={{
-              "border-color": confidenceBorder(fb.confidence),
-              "pointer-events": "auto",
-            }}
-          >
-            {/* Colored left accent bar */}
-            <div
-              class="mt-0.5 h-4 w-1 shrink-0 rounded-full"
-              style={{ background: confidenceAccent(fb.confidence) }}
-              aria-hidden="true"
-            />
-            <div class="flex-1 text-sm leading-snug">
-              <span class="font-semibold" style={{ color: confidenceAccent(fb.confidence) }}>
-                {confidenceLabel(fb.confidence)}
-              </span>
-              <span class="ml-1 text-gray-500">
-                {parts.length > 0
-                  ? `— imported ${parts.join(", ")}.`
-                  : "— check each section for accuracy."}
-              </span>
-            </div>
-            <button
-              type="button"
-              onClick={() => setImportFeedback(null)}
-              class="shrink-0 text-gray-400 transition-colors hover:text-gray-600"
-              aria-label="Dismiss"
-            >
-              <svg
-                width="14"
-                height="14"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="2"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                aria-hidden="true"
-              >
-                <line x1="18" y1="6" x2="6" y2="18" />
-                <line x1="6" y1="6" x2="18" y2="18" />
-              </svg>
-            </button>
-          </div>
-        );
-      }}
-    </Show>
-  );
-}
-
 function ToastContainer() {
   return (
     <div
@@ -249,8 +156,57 @@ function ToastContainer() {
     >
       <ExportErrorToast />
       <ImportErrorToast />
-      <ImportSuccessToast />
     </div>
+  );
+}
+
+function ImportReviewCard() {
+  return (
+    <Show when={importReview() && !importReview()!.dismissed}>
+      {(_) => {
+        const review = importReview()!;
+        const confidence = getImportConfidenceState(review.feedback.confidence);
+
+        return (
+          <section
+            class="border-b px-6 py-4"
+            style={{ background: "#ffffff", "border-color": confidence.border }}
+          >
+            <div class="mx-auto flex max-w-6xl items-start gap-4">
+              <div
+                class="mt-0.5 h-12 w-1.5 shrink-0 rounded-full"
+                style={{ background: confidence.accent }}
+                aria-hidden="true"
+              />
+              <div class="min-w-0 flex-1">
+                <div class="flex flex-wrap items-center gap-2">
+                  <p class="text-sm font-semibold" style={{ color: confidence.accent }}>
+                    {confidence.label}
+                  </p>
+                  <span class="rounded-full bg-slate-100 px-2 py-0.5 text-xs font-medium text-slate-600">
+                    {review.feedback.confidence}/100
+                  </span>
+                </div>
+                <p class="mt-1 text-sm text-slate-700">
+                  {formatImportReviewCounts(review.feedback)} Review each section before exporting.
+                </p>
+                <p class="mt-1 text-xs text-slate-500">
+                  This reflects parser confidence only — it is not an ATS guarantee.
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={dismissImportReview}
+                class="shrink-0 rounded-md px-2 py-1 text-sm text-slate-400 transition-colors hover:bg-slate-100 hover:text-slate-600"
+                aria-label="Dismiss import review card"
+              >
+                ✕
+              </button>
+            </div>
+          </section>
+        );
+      }}
+    </Show>
   );
 }
 
@@ -282,6 +238,7 @@ export default function EditorLayout() {
       }}
     >
       <ToastContainer />
+      <ImportReviewCard />
 
       {/* Panels row */}
       <div

--- a/src/components/upload/FileUpload.tsx
+++ b/src/components/upload/FileUpload.tsx
@@ -3,7 +3,7 @@ import { type Component, createSignal, Show } from "solid-js";
 import ProcessingIndicator from "@/components/ui/ProcessingIndicator";
 import { importResumeFile } from "@/lib/upload/import-resume";
 import { validateUploadFile } from "@/lib/upload/guardrails";
-import { loadResume, setImportFeedback } from "@/store/resume";
+import { clearImportReview, loadResume, showImportReview } from "@/store/resume";
 
 type Status = "idle" | "processing" | "error";
 
@@ -32,7 +32,9 @@ const FileUpload: Component = () => {
     }
 
     if (outcome.feedback) {
-      setImportFeedback(outcome.feedback);
+      showImportReview(outcome.feedback);
+    } else {
+      clearImportReview();
     }
     loadResume(outcome.resume);
 
@@ -62,6 +64,7 @@ const FileUpload: Component = () => {
   const handleDragLeave = () => setIsDragOver(false);
 
   const startFromScratch = async () => {
+    clearImportReview();
     const { navigate } = await import("astro:transitions/client");
     navigate("/editor");
   };

--- a/src/lib/editor/import-review.test.ts
+++ b/src/lib/editor/import-review.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+import type { ImportFeedback } from "@/store/resume";
+
+import { formatImportReviewCounts, getImportConfidenceState } from "./import-review";
+
+function createFeedback(overrides?: Partial<ImportFeedback>): ImportFeedback {
+  return {
+    confidence: 72,
+    work: 2,
+    education: 1,
+    skills: 3,
+    projects: 0,
+    certificates: 0,
+    ...overrides,
+  };
+}
+
+describe("import review helpers", () => {
+  it("maps parser confidence scores on the real 0-100 scale", () => {
+    expect(getImportConfidenceState(90).label).toBe("High parse confidence");
+    expect(getImportConfidenceState(65).label).toBe("Medium parse confidence");
+    expect(getImportConfidenceState(35).label).toBe("Low parse confidence");
+  });
+
+  it("summarizes imported section counts for the review card", () => {
+    expect(formatImportReviewCounts(createFeedback())).toBe(
+      "Imported 2 jobs, 1 education entry, and 3 skills."
+    );
+    expect(formatImportReviewCounts(createFeedback({ work: 0, education: 0, skills: 0 }))).toBe(
+      "Imported content is available to review section by section."
+    );
+  });
+});

--- a/src/lib/editor/import-review.ts
+++ b/src/lib/editor/import-review.ts
@@ -1,0 +1,63 @@
+import type { ImportFeedback } from "@/store/resume";
+
+export function getImportConfidenceState(score: number): {
+  accent: string;
+  border: string;
+  label: string;
+} {
+  if (score >= 80) {
+    return {
+      label: "High parse confidence",
+      accent: "#1d6648",
+      border: "#bbf7d0",
+    };
+  }
+
+  if (score >= 50) {
+    return {
+      label: "Medium parse confidence",
+      accent: "#b45309",
+      border: "#fcd34d",
+    };
+  }
+
+  return {
+    label: "Low parse confidence",
+    accent: "#b91c1c",
+    border: "#fca5a5",
+  };
+}
+
+export function formatImportReviewCounts(feedback: ImportFeedback): string {
+  const parts: string[] = [];
+
+  if (feedback.work > 0) {
+    parts.push(`${feedback.work} job${feedback.work > 1 ? "s" : ""}`);
+  }
+
+  if (feedback.education > 0) {
+    parts.push(`${feedback.education} education entr${feedback.education > 1 ? "ies" : "y"}`);
+  }
+
+  if (feedback.skills > 0) {
+    parts.push(`${feedback.skills} skill${feedback.skills > 1 ? "s" : ""}`);
+  }
+
+  if (feedback.projects > 0) {
+    parts.push(`${feedback.projects} project${feedback.projects > 1 ? "s" : ""}`);
+  }
+
+  if (feedback.certificates > 0) {
+    parts.push(`${feedback.certificates} certificate${feedback.certificates > 1 ? "s" : ""}`);
+  }
+
+  if (parts.length === 0) {
+    return "Imported content is available to review section by section.";
+  }
+
+  if (parts.length === 1) {
+    return `Imported ${parts[0]}.`;
+  }
+
+  return `Imported ${parts.slice(0, -1).join(", ")}, and ${parts.at(-1)}.`;
+}

--- a/src/store/resume.ts
+++ b/src/store/resume.ts
@@ -30,11 +30,31 @@ export interface ImportFeedback {
   certificates: number;
 }
 
+export interface ImportReviewState {
+  dismissed: boolean;
+  feedback: ImportFeedback;
+}
+
 export const [exportError, setExportError] = createSignal("");
 
 export const [importError, setImportError] = createSignal("");
 
-export const [importFeedback, setImportFeedback] = createSignal<ImportFeedback | null>(null);
+export const [importReview, setImportReview] = createSignal<ImportReviewState | null>(null);
+
+export function showImportReview(feedback: ImportFeedback) {
+  setImportReview({
+    feedback,
+    dismissed: false,
+  });
+}
+
+export function dismissImportReview() {
+  setImportReview((current) => (current ? { ...current, dismissed: true } : null));
+}
+
+export function clearImportReview() {
+  setImportReview(null);
+}
 
 export function loadResume(data: ResumeSchema) {
   setResume(normalizeResume(data));


### PR DESCRIPTION
## Summary
Replaces the temporary parser-confidence toast with a persistent import review card that stays visible until dismissed or the session is reset. The card now uses the real 0–100 confidence scale, explains that the score is parser confidence rather than an ATS guarantee, and clears on fresh starts or draft restores.

## Changes
- add import review helpers and store actions for showing, dismissing, and clearing parser review state
- replace the transient success toast with a persistent editor review card that shows score, imported counts, and reviewer guidance
- clear stale import review state on fresh starts, JSON imports without parser feedback, and draft restores

## Testing
- [x] bun run verify
- [x] bun run test -- src/lib/editor/import-review.test.ts

## References
- Ticket/Issue: Fixes #8