### PR TITLE
feat: add paper size controls for preview and export

### DIFF
--- a/src/components/editor/CommandBar.tsx
+++ b/src/components/editor/CommandBar.tsx
@@ -9,6 +9,7 @@ import {
   loadResume,
   resume,
   selectedAccentColor,
+  selectedPageFormat,
   selectedTemplate,
   setActiveSection,
   setExportError,
@@ -56,6 +57,7 @@ const CommandBar: Component = () => {
       setIsExporting(true);
       await exportPDF(JSON.parse(JSON.stringify(resume)), selectedTemplate(), {
         accentColor: selectedAccentColor(),
+        pageFormat: selectedPageFormat(),
       });
     } catch (error) {
       const msg = error instanceof Error ? error.message : "Unable to export this resume yet.";

--- a/src/components/preview/ResumePreview.tsx
+++ b/src/components/preview/ResumePreview.tsx
@@ -1,10 +1,16 @@
 import { type Component, For, Show } from "solid-js";
 
-import { TEMPLATE_OPTIONS } from "@/lib/templates/registry";
 import ResumeDocument from "@/components/resume/ResumeDocument";
 import { resolveResumeDesignSettings } from "@/lib/resume/design";
-import { resume, selectedTemplate, setSelectedTemplate } from "@/store/resume";
-import { selectedAccentColor } from "@/store/resume";
+import { TEMPLATE_OPTIONS } from "@/lib/templates/registry";
+import {
+  resume,
+  selectedAccentColor,
+  selectedPageFormat,
+  selectedTemplate,
+  setSelectedPageFormat,
+  setSelectedTemplate,
+} from "@/store/resume";
 
 const TOTAL_SECTIONS = 7;
 const CIRCUMFERENCE = 2 * Math.PI * 14;
@@ -23,6 +29,7 @@ const ResumePreview: Component = () => {
     resolveResumeDesignSettings({
       template: selectedTemplate(),
       accentColor: selectedAccentColor(),
+      pageFormat: selectedPageFormat(),
     });
 
   const completedCount = () => {
@@ -85,29 +92,54 @@ const ResumePreview: Component = () => {
           </span>
         </div>
 
-        <div class="flex gap-1.5">
-          <For each={TEMPLATE_OPTIONS}>
-            {(tpl) => (
-              <button
-                type="button"
-                onClick={() => setSelectedTemplate(tpl.id)}
-                aria-pressed={selectedTemplate() === tpl.id}
-                title={tpl.description}
-                class={`rounded-md px-3 py-1.5 text-xs font-medium transition-colors active:scale-95 ${selectedTemplate() === tpl.id ? "" : "hover:bg-[#e6f0ea]"}`}
-                style={
-                  selectedTemplate() === tpl.id
-                    ? { background: "#1d6648", color: "#ffffff" }
-                    : {
-                        background: "#f4f8f5",
-                        color: "#3d5c49",
-                        border: "1px solid #ccddd4",
-                      }
-                }
-              >
-                {tpl.label}
-              </button>
-            )}
-          </For>
+        <div class="flex flex-wrap gap-3">
+          <div class="flex gap-1.5">
+            <For each={TEMPLATE_OPTIONS}>
+              {(tpl) => (
+                <button
+                  type="button"
+                  onClick={() => setSelectedTemplate(tpl.id)}
+                  aria-pressed={selectedTemplate() === tpl.id}
+                  title={tpl.description}
+                  class={`rounded-md px-3 py-1.5 text-xs font-medium transition-colors active:scale-95 ${selectedTemplate() === tpl.id ? "" : "hover:bg-[#e6f0ea]"}`}
+                  style={
+                    selectedTemplate() === tpl.id
+                      ? { background: "#1d6648", color: "#ffffff" }
+                      : {
+                          background: "#f4f8f5",
+                          color: "#3d5c49",
+                          border: "1px solid #ccddd4",
+                        }
+                  }
+                >
+                  {tpl.label}
+                </button>
+              )}
+            </For>
+          </div>
+
+          <div class="flex items-center gap-1 rounded-md border border-[#ccddd4] bg-[#f4f8f5] p-1">
+            <span class="px-2 text-[11px] font-medium uppercase tracking-wide text-[#5a7a68]">
+              Paper
+            </span>
+            <For each={["A4", "Letter"] as const}>
+              {(format) => (
+                <button
+                  type="button"
+                  onClick={() => setSelectedPageFormat(format)}
+                  aria-pressed={selectedPageFormat() === format}
+                  class="rounded-md px-3 py-1.5 text-xs font-medium transition-colors active:scale-95"
+                  style={
+                    selectedPageFormat() === format
+                      ? { background: "#ffffff", color: "#0e2418", border: "1px solid #ccddd4" }
+                      : { color: "#5a7a68" }
+                  }
+                >
+                  {format}
+                </button>
+              )}
+            </For>
+          </div>
         </div>
       </div>
 
@@ -161,8 +193,9 @@ const ResumePreview: Component = () => {
       >
         <div class="flex-1 overflow-y-auto p-8">
           <div
-            class="resume-document__page mx-auto max-w-[680px] rounded-sm bg-white p-10 text-xs leading-relaxed shadow-lg"
+            class="resume-document__page mx-auto rounded-sm bg-white p-10 text-xs leading-relaxed shadow-lg"
             style={{
+              width: `min(100%, ${design().previewPageWidth}px)`,
               "font-family": design().previewFontFamily,
               "min-height": `${design().previewPageMinHeight}px`,
             }}

--- a/src/lib/resume/design.test.ts
+++ b/src/lib/resume/design.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import { DEFAULT_PAGE_FORMAT, resolveResumeDesignSettings } from "./design";
+
+describe("resume design settings", () => {
+  it("defaults to A4 page sizing", () => {
+    const design = resolveResumeDesignSettings({ template: "modern" });
+
+    expect(design.pageFormat).toBe(DEFAULT_PAGE_FORMAT);
+    expect(design.pageSize).toBe("A4");
+    expect(design.previewPageMinHeight).toBe(842);
+  });
+
+  it("maps Letter page sizing for preview and export parity", () => {
+    const design = resolveResumeDesignSettings({
+      template: "modern",
+      pageFormat: "Letter",
+    });
+
+    expect(design.pageFormat).toBe("Letter");
+    expect(design.pageSize).toBe("LETTER");
+    expect(design.previewPageMinHeight).toBe(816);
+    expect(design.pageWidth).toBe(612);
+  });
+});

--- a/src/lib/resume/design.ts
+++ b/src/lib/resume/design.ts
@@ -57,7 +57,7 @@ const PAGE_FORMAT_DIMENSIONS: Record<
     pageSize: "LETTER",
     pageWidth: 612,
     pageHeight: 792,
-    previewPageWidth: 680,
+    previewPageWidth: 698,
     previewPageMinHeight: 816,
   },
 };

--- a/src/store/resume.ts
+++ b/src/store/resume.ts
@@ -1,7 +1,11 @@
 import { createSignal } from "solid-js";
 import { createStore } from "solid-js/store";
 
-import { DEFAULT_RESUME_ACCENT_COLOR } from "@/lib/resume/design";
+import {
+  DEFAULT_PAGE_FORMAT,
+  DEFAULT_RESUME_ACCENT_COLOR,
+  type PageFormat,
+} from "@/lib/resume/design";
 import { normalizeResume } from "@/lib/resume/normalize";
 import { DEFAULT_TEMPLATE_ID, type TemplateId } from "@/types/template";
 import { EMPTY_RESUME } from "@/types/resume";
@@ -18,6 +22,9 @@ export const [selectedTemplate, setSelectedTemplate] =
 export const [selectedAccentColor, setSelectedAccentColor] = createSignal(
   DEFAULT_RESUME_ACCENT_COLOR
 );
+
+export const [selectedPageFormat, setSelectedPageFormat] =
+  createSignal<PageFormat>(DEFAULT_PAGE_FORMAT);
 
 export const [activeSection, setActiveSection] = createSignal<SectionId>("basics");
 


### PR DESCRIPTION
## Summary
Adds an A4/Letter paper-size control to the preview surface and wires the selected format through to PDF export. The preview document now changes dimensions with the selected paper size so the on-screen layout stays aligned with the exported page format.

## Changes
- add page-format editor state with A4 as the default
- pass the selected page format into both preview design settings and PDF export
- add a preview control for switching between A4 and Letter and update preview width/height to reflect the chosen format

## Testing
- [x] bun run verify
- [x] bun run test -- src/lib/resume/design.test.ts

## References
- Ticket/Issue: Fixes #13