### PR TITLE
feat: add languages interests and references forms

### DIFF
--- a/src/components/editor/CommandBar.tsx
+++ b/src/components/editor/CommandBar.tsx
@@ -30,6 +30,13 @@ const SECTIONS: Section[] = [
   { id: "work", label: "Work", isDone: () => (resume.work?.length ?? 0) > 0 },
   { id: "education", label: "Education", isDone: () => (resume.education?.length ?? 0) > 0 },
   { id: "skills", label: "Skills", isDone: () => (resume.skills?.length ?? 0) > 0 },
+  { id: "languages", label: "Languages", isDone: () => (resume.languages?.length ?? 0) > 0 },
+  { id: "interests", label: "Interests", isDone: () => (resume.interests?.length ?? 0) > 0 },
+  {
+    id: "references",
+    label: "References",
+    isDone: () => (resume.references?.length ?? 0) > 0,
+  },
   { id: "projects", label: "Projects", isDone: () => (resume.projects?.length ?? 0) > 0 },
   { id: "certs", label: "Certs", isDone: () => (resume.certificates?.length ?? 0) > 0 },
 ];

--- a/src/components/editor/EditorShell.tsx
+++ b/src/components/editor/EditorShell.tsx
@@ -6,7 +6,10 @@ import type { SectionId } from "@/types/resume";
 import BasicsForm from "./BasicsForm";
 import CertificatesForm from "./CertificatesForm";
 import EducationForm from "./EducationForm";
+import InterestsForm from "./InterestsForm";
+import LanguagesForm from "./LanguagesForm";
 import ProjectsForm from "./ProjectsForm";
+import ReferencesForm from "./ReferencesForm";
 import SkillsForm from "./SkillsForm";
 import SummaryForm from "./SummaryForm";
 import WorkForm from "./WorkForm";
@@ -48,6 +51,24 @@ const SECTIONS: SectionMeta[] = [
     label: "Skills",
     subtitle: "Technical and professional skills",
     component: () => <SkillsForm />,
+  },
+  {
+    id: "languages",
+    label: "Languages",
+    subtitle: "Languages and fluency levels",
+    component: () => <LanguagesForm />,
+  },
+  {
+    id: "interests",
+    label: "Interests",
+    subtitle: "Communities, hobbies, and focus areas",
+    component: () => <InterestsForm />,
+  },
+  {
+    id: "references",
+    label: "References",
+    subtitle: "People who can vouch for your work",
+    component: () => <ReferencesForm />,
   },
   {
     id: "projects",

--- a/src/components/editor/InterestsForm.tsx
+++ b/src/components/editor/InterestsForm.tsx
@@ -1,0 +1,77 @@
+import type { Component } from "solid-js";
+
+import FormField from "@/components/ui/FormField";
+import Input from "@/components/ui/Input";
+import { ReorderableList } from "@/components/ui/ReorderableList";
+import { resume, setResume } from "@/store/resume";
+import type { ResumeInterest } from "@/types/resume";
+
+function newInterest(): ResumeInterest {
+  return {
+    id: crypto.randomUUID(),
+    name: "",
+    keywords: [],
+  };
+}
+
+function parseKeywords(value: string): string[] {
+  return value
+    .split(",")
+    .map((keyword) => keyword.trim())
+    .filter(Boolean);
+}
+
+const InterestsForm: Component = () => {
+  const addEntry = () => {
+    setResume("interests", (entries) => [...(entries ?? []), newInterest()]);
+  };
+
+  const removeEntry = (id: string) => {
+    setResume("interests", (entries) => (entries ?? []).filter((entry) => entry.id !== id));
+  };
+
+  const reorder = (items: ResumeInterest[]) => {
+    setResume("interests", items);
+  };
+
+  const updateField = <K extends keyof ResumeInterest>(
+    id: string,
+    field: K,
+    value: ResumeInterest[K]
+  ) => {
+    setResume("interests", (entry) => entry?.id === id, field, value);
+  };
+
+  return (
+    <ReorderableList
+      items={resume.interests ?? []}
+      onReorder={reorder}
+      onRemove={removeEntry}
+      onAdd={addEntry}
+      addLabel="Add interest"
+      renderItem={(item) => (
+        <div class="space-y-3 pr-12">
+          <FormField label="Interest" id={`interest-name-${item.id}`}>
+            <Input
+              id={`interest-name-${item.id}`}
+              value={item.name}
+              onInput={(v) => updateField(item.id, "name", v)}
+              placeholder="Open source"
+            />
+          </FormField>
+
+          <FormField label="Keywords (optional)" id={`interest-keywords-${item.id}`}>
+            <Input
+              id={`interest-keywords-${item.id}`}
+              value={(item.keywords ?? []).join(", ")}
+              onInput={(v) => updateField(item.id, "keywords", parseKeywords(v))}
+              placeholder="community, mentoring, web performance"
+            />
+          </FormField>
+        </div>
+      )}
+    />
+  );
+};
+
+export default InterestsForm;

--- a/src/components/editor/LanguagesForm.tsx
+++ b/src/components/editor/LanguagesForm.tsx
@@ -1,0 +1,71 @@
+import type { Component } from "solid-js";
+
+import FormField from "@/components/ui/FormField";
+import Input from "@/components/ui/Input";
+import { ReorderableList } from "@/components/ui/ReorderableList";
+import { resume, setResume } from "@/store/resume";
+import type { ResumeLanguage } from "@/types/resume";
+
+function newLanguage(): ResumeLanguage {
+  return {
+    id: crypto.randomUUID(),
+    language: "",
+    fluency: "",
+  };
+}
+
+const LanguagesForm: Component = () => {
+  const addEntry = () => {
+    setResume("languages", (entries) => [...(entries ?? []), newLanguage()]);
+  };
+
+  const removeEntry = (id: string) => {
+    setResume("languages", (entries) => (entries ?? []).filter((entry) => entry.id !== id));
+  };
+
+  const reorder = (items: ResumeLanguage[]) => {
+    setResume("languages", items);
+  };
+
+  const updateField = <K extends keyof ResumeLanguage>(
+    id: string,
+    field: K,
+    value: ResumeLanguage[K]
+  ) => {
+    setResume("languages", (entry) => entry?.id === id, field, value);
+  };
+
+  return (
+    <ReorderableList
+      items={resume.languages ?? []}
+      onReorder={reorder}
+      onRemove={removeEntry}
+      onAdd={addEntry}
+      addLabel="Add language"
+      renderItem={(item) => (
+        <div class="space-y-3 pr-12">
+          <div class="grid grid-cols-2 gap-3">
+            <FormField label="Language" id={`lang-name-${item.id}`}>
+              <Input
+                id={`lang-name-${item.id}`}
+                value={item.language}
+                onInput={(v) => updateField(item.id, "language", v)}
+                placeholder="English"
+              />
+            </FormField>
+            <FormField label="Fluency" id={`lang-fluency-${item.id}`}>
+              <Input
+                id={`lang-fluency-${item.id}`}
+                value={item.fluency ?? ""}
+                onInput={(v) => updateField(item.id, "fluency", v)}
+                placeholder="Native"
+              />
+            </FormField>
+          </div>
+        </div>
+      )}
+    />
+  );
+};
+
+export default LanguagesForm;

--- a/src/components/editor/ReferencesForm.tsx
+++ b/src/components/editor/ReferencesForm.tsx
@@ -1,0 +1,72 @@
+import type { Component } from "solid-js";
+
+import FormField from "@/components/ui/FormField";
+import Input from "@/components/ui/Input";
+import { ReorderableList } from "@/components/ui/ReorderableList";
+import Textarea from "@/components/ui/Textarea";
+import { resume, setResume } from "@/store/resume";
+import type { ResumeReference } from "@/types/resume";
+
+function newReference(): ResumeReference {
+  return {
+    id: crypto.randomUUID(),
+    name: "",
+    reference: "",
+  };
+}
+
+const ReferencesForm: Component = () => {
+  const addEntry = () => {
+    setResume("references", (entries) => [...(entries ?? []), newReference()]);
+  };
+
+  const removeEntry = (id: string) => {
+    setResume("references", (entries) => (entries ?? []).filter((entry) => entry.id !== id));
+  };
+
+  const reorder = (items: ResumeReference[]) => {
+    setResume("references", items);
+  };
+
+  const updateField = <K extends keyof ResumeReference>(
+    id: string,
+    field: K,
+    value: ResumeReference[K]
+  ) => {
+    setResume("references", (entry) => entry?.id === id, field, value);
+  };
+
+  return (
+    <ReorderableList
+      items={resume.references ?? []}
+      onReorder={reorder}
+      onRemove={removeEntry}
+      onAdd={addEntry}
+      addLabel="Add reference"
+      renderItem={(item) => (
+        <div class="space-y-3 pr-12">
+          <FormField label="Reference Name" id={`reference-name-${item.id}`}>
+            <Input
+              id={`reference-name-${item.id}`}
+              value={item.name}
+              onInput={(v) => updateField(item.id, "name", v)}
+              placeholder="Alex Smith"
+            />
+          </FormField>
+
+          <FormField label="Reference" id={`reference-text-${item.id}`}>
+            <Textarea
+              id={`reference-text-${item.id}`}
+              value={item.reference ?? ""}
+              onInput={(v) => updateField(item.id, "reference", v)}
+              placeholder="Worked closely with Alex for three years..."
+              rows={3}
+            />
+          </FormField>
+        </div>
+      )}
+    />
+  );
+};
+
+export default ReferencesForm;

--- a/src/components/preview/ResumePreview.tsx
+++ b/src/components/preview/ResumePreview.tsx
@@ -6,7 +6,7 @@ import { resolveResumeDesignSettings } from "@/lib/resume/design";
 import { resume, selectedTemplate, setSelectedTemplate } from "@/store/resume";
 import { selectedAccentColor } from "@/store/resume";
 
-const TOTAL_SECTIONS = 7;
+const TOTAL_SECTIONS = 10;
 const CIRCUMFERENCE = 2 * Math.PI * 14;
 
 const isEmpty = () =>
@@ -15,6 +15,9 @@ const isEmpty = () =>
   (resume.work?.length ?? 0) === 0 &&
   (resume.education?.length ?? 0) === 0 &&
   (resume.skills?.length ?? 0) === 0 &&
+  (resume.languages?.length ?? 0) === 0 &&
+  (resume.interests?.length ?? 0) === 0 &&
+  (resume.references?.length ?? 0) === 0 &&
   (resume.projects?.length ?? 0) === 0 &&
   (resume.certificates?.length ?? 0) === 0;
 
@@ -32,6 +35,9 @@ const ResumePreview: Component = () => {
     if ((resume.work?.length ?? 0) > 0) count++;
     if ((resume.education?.length ?? 0) > 0) count++;
     if ((resume.skills?.length ?? 0) > 0) count++;
+    if ((resume.languages?.length ?? 0) > 0) count++;
+    if ((resume.interests?.length ?? 0) > 0) count++;
+    if ((resume.references?.length ?? 0) > 0) count++;
     if ((resume.projects?.length ?? 0) > 0) count++;
     if ((resume.certificates?.length ?? 0) > 0) count++;
     return count;

--- a/src/types/resume.ts
+++ b/src/types/resume.ts
@@ -148,6 +148,9 @@ export type SectionId =
   | "work"
   | "education"
   | "skills"
+  | "languages"
+  | "interests"
+  | "references"
   | "projects"
   | "certs";
 


### PR DESCRIPTION
## Summary
Adds editor support for languages, interests, and references so these schema-backed sections can finally be managed in the main form UI. The navigation and completeness UI now recognize the new sections and the existing preview/export pipeline continues to render them.

## Changes
- add new SolidJS forms for languages, interests, and references using the shared reorderable list pattern
- register the new sections in active-section typing, editor navigation, and completion metrics
- keep the preview/export behavior unchanged while exposing the sections for normal editing and draft round-tripping

## Testing
- [x] bun run verify
- [x] bun run build

## References
- Ticket/Issue: Fixes #54