### PR TITLE
feat: add global design controls

### DIFF
--- a/src/components/editor/CommandBar.tsx
+++ b/src/components/editor/CommandBar.tsx
@@ -9,6 +9,7 @@ import {
   loadResume,
   resume,
   selectedAccentColor,
+  selectedFontId,
   selectedTemplate,
   setActiveSection,
   setExportError,
@@ -56,6 +57,7 @@ const CommandBar: Component = () => {
       setIsExporting(true);
       await exportPDF(JSON.parse(JSON.stringify(resume)), selectedTemplate(), {
         accentColor: selectedAccentColor(),
+        font: selectedFontId(),
       });
     } catch (error) {
       const msg = error instanceof Error ? error.message : "Unable to export this resume yet.";

--- a/src/components/preview/ResumePreview.tsx
+++ b/src/components/preview/ResumePreview.tsx
@@ -1,13 +1,22 @@
 import { type Component, For, Show } from "solid-js";
 
-import { TEMPLATE_OPTIONS } from "@/lib/templates/registry";
 import ResumeDocument from "@/components/resume/ResumeDocument";
+import { getPdfFont, PDF_FONT_OPTIONS, type PdfFontId } from "@/lib/export/fonts";
 import { resolveResumeDesignSettings } from "@/lib/resume/design";
-import { resume, selectedTemplate, setSelectedTemplate } from "@/store/resume";
-import { selectedAccentColor } from "@/store/resume";
+import { TEMPLATE_OPTIONS } from "@/lib/templates/registry";
+import {
+  resume,
+  selectedAccentColor,
+  selectedFontId,
+  selectedTemplate,
+  setSelectedAccentColor,
+  setSelectedFontId,
+  setSelectedTemplate,
+} from "@/store/resume";
 
 const TOTAL_SECTIONS = 7;
 const CIRCUMFERENCE = 2 * Math.PI * 14;
+const ACCENT_COLOR_OPTIONS = ["#1d6648", "#2563eb", "#7c3aed", "#be185d", "#c2410c"];
 
 const isEmpty = () =>
   !resume.basics.name &&
@@ -23,6 +32,9 @@ const ResumePreview: Component = () => {
     resolveResumeDesignSettings({
       template: selectedTemplate(),
       accentColor: selectedAccentColor(),
+      typography: {
+        previewFontFamily: getPdfFont(selectedFontId()).previewFontFamily,
+      },
     });
 
   const completedCount = () => {
@@ -85,29 +97,74 @@ const ResumePreview: Component = () => {
           </span>
         </div>
 
-        <div class="flex gap-1.5">
-          <For each={TEMPLATE_OPTIONS}>
-            {(tpl) => (
-              <button
-                type="button"
-                onClick={() => setSelectedTemplate(tpl.id)}
-                aria-pressed={selectedTemplate() === tpl.id}
-                title={tpl.description}
-                class={`rounded-md px-3 py-1.5 text-xs font-medium transition-colors active:scale-95 ${selectedTemplate() === tpl.id ? "" : "hover:bg-[#e6f0ea]"}`}
-                style={
-                  selectedTemplate() === tpl.id
-                    ? { background: "#1d6648", color: "#ffffff" }
-                    : {
-                        background: "#f4f8f5",
-                        color: "#3d5c49",
-                        border: "1px solid #ccddd4",
-                      }
-                }
-              >
-                {tpl.label}
-              </button>
-            )}
-          </For>
+        <div class="flex flex-wrap gap-3">
+          <div class="flex gap-1.5">
+            <For each={TEMPLATE_OPTIONS}>
+              {(tpl) => (
+                <button
+                  type="button"
+                  onClick={() => setSelectedTemplate(tpl.id)}
+                  aria-pressed={selectedTemplate() === tpl.id}
+                  title={tpl.description}
+                  class={`rounded-md px-3 py-1.5 text-xs font-medium transition-colors active:scale-95 ${selectedTemplate() === tpl.id ? "" : "hover:bg-[#e6f0ea]"}`}
+                  style={
+                    selectedTemplate() === tpl.id
+                      ? { background: "#1d6648", color: "#ffffff" }
+                      : {
+                          background: "#f4f8f5",
+                          color: "#3d5c49",
+                          border: "1px solid #ccddd4",
+                        }
+                  }
+                >
+                  {tpl.label}
+                </button>
+              )}
+            </For>
+          </div>
+
+          <div class="flex items-center gap-2 rounded-md border border-[#ccddd4] bg-[#f4f8f5] px-3 py-1.5">
+            <span class="text-[11px] font-medium uppercase tracking-wide text-[#5a7a68]">
+              Accent
+            </span>
+            <div class="flex items-center gap-1.5">
+              <For each={ACCENT_COLOR_OPTIONS}>
+                {(color) => (
+                  <button
+                    type="button"
+                    onClick={() => setSelectedAccentColor(color)}
+                    aria-label={`Use accent color ${color}`}
+                    aria-pressed={selectedAccentColor() === color}
+                    class="h-5 w-5 rounded-full border-2 transition-transform hover:scale-105"
+                    style={{
+                      background: color,
+                      "border-color": selectedAccentColor() === color ? "#0e2418" : "#ffffff",
+                    }}
+                  />
+                )}
+              </For>
+              <input
+                type="color"
+                value={selectedAccentColor()}
+                onInput={(event) => setSelectedAccentColor(event.currentTarget.value)}
+                aria-label="Choose custom accent color"
+                class="h-7 w-8 cursor-pointer rounded border border-[#ccddd4] bg-white p-0.5"
+              />
+            </div>
+          </div>
+
+          <label class="flex items-center gap-2 rounded-md border border-[#ccddd4] bg-[#f4f8f5] px-3 py-1.5 text-xs text-[#3d5c49]">
+            <span class="text-[11px] font-medium uppercase tracking-wide text-[#5a7a68]">Font</span>
+            <select
+              value={selectedFontId()}
+              onChange={(event) => setSelectedFontId(event.currentTarget.value as PdfFontId)}
+              class="rounded-md border border-[#ccddd4] bg-white px-2 py-1 text-xs text-[#0e2418]"
+            >
+              <For each={PDF_FONT_OPTIONS}>
+                {(font) => <option value={font.id}>{font.label}</option>}
+              </For>
+            </select>
+          </label>
         </div>
       </div>
 

--- a/src/lib/export/fonts.ts
+++ b/src/lib/export/fonts.ts
@@ -1,4 +1,4 @@
-export type PdfFontId = "roboto";
+export type PdfFontId = "roboto" | "helvetica" | "times";
 
 export interface PdfMakeFontRuntime {
   addFonts?: (fonts: Record<string, object>) => void;
@@ -9,6 +9,7 @@ export interface PdfFontConfig {
   family: string;
   id: PdfFontId;
   label: string;
+  previewFontFamily: string;
   register: (pdfMake: PdfMakeFontRuntime) => Promise<void>;
 }
 
@@ -19,6 +20,7 @@ export const PDF_FONTS: Record<PdfFontId, PdfFontConfig> = {
     id: "roboto",
     label: "Roboto",
     family: "Roboto",
+    previewFontFamily: '"Roboto", "Geist", Arial, sans-serif',
     register: async (pdfMake) => {
       const vfsFonts = await import("pdfmake/build/vfs_fonts");
       const robotoVfs = (vfsFonts.default ?? vfsFonts) as Record<string, string>;
@@ -34,7 +36,41 @@ export const PDF_FONTS: Record<PdfFontId, PdfFontConfig> = {
       });
     },
   },
+  helvetica: {
+    id: "helvetica",
+    label: "Helvetica",
+    family: "Helvetica",
+    previewFontFamily: '"Helvetica Neue", Arial, sans-serif',
+    register: async (pdfMake) => {
+      pdfMake.addFonts?.({
+        Helvetica: {
+          normal: "Helvetica",
+          bold: "Helvetica-Bold",
+          italics: "Helvetica-Oblique",
+          bolditalics: "Helvetica-BoldOblique",
+        },
+      });
+    },
+  },
+  times: {
+    id: "times",
+    label: "Times New Roman",
+    family: "Times",
+    previewFontFamily: '"Times New Roman", Georgia, serif',
+    register: async (pdfMake) => {
+      pdfMake.addFonts?.({
+        Times: {
+          normal: "Times-Roman",
+          bold: "Times-Bold",
+          italics: "Times-Italic",
+          bolditalics: "Times-BoldItalic",
+        },
+      });
+    },
+  },
 };
+
+export const PDF_FONT_OPTIONS = Object.values(PDF_FONTS);
 
 export function getPdfFont(fontId: PdfFontId = DEFAULT_PDF_FONT): PdfFontConfig {
   return PDF_FONTS[fontId];

--- a/src/lib/export/pdf-export.test.ts
+++ b/src/lib/export/pdf-export.test.ts
@@ -187,6 +187,26 @@ describe("exportPDF", () => {
     expect(click).not.toHaveBeenCalled();
   });
 
+  it("registers and uses non-default font choices", async () => {
+    const { exportPDF } = await import("./pdf-export");
+
+    await exportPDF(createTemplateFixture(), "modern", {
+      font: "helvetica",
+    });
+
+    expect(addFonts).toHaveBeenCalledWith(
+      expect.objectContaining({
+        Helvetica: expect.objectContaining({ normal: "Helvetica" }),
+      })
+    );
+
+    const docDefinition = (createPdf.mock.calls as unknown[][]).at(0)?.[0] as {
+      defaultStyle: { font: string };
+    };
+
+    expect(docDefinition.defaultStyle.font).toBe("Helvetica");
+  });
+
   it.each(["modern", "minimal", "compact-ats"] as const)(
     "creates a valid pdf definition for %s and propagates options",
     async (template) => {

--- a/src/lib/export/pdf-export.ts
+++ b/src/lib/export/pdf-export.ts
@@ -6,16 +6,20 @@ import type { ResumeSchema, TemplateId } from "@/types/resume";
 import { ResumeExportValidationError, validateResumeForExport } from "@/lib/resume/normalize";
 import type { TDocumentDefinitions } from "pdfmake/interfaces";
 
-let fontRegistrationPromise: Promise<void> | null = null;
+const fontRegistrationPromises = new Map<PdfFontId, Promise<void>>();
 
-async function ensurePdfMakeFontsRegistered(pdfMake: PdfMakeFontRuntime): Promise<void> {
-  if (!fontRegistrationPromise) {
-    fontRegistrationPromise = (async () => {
-      await getPdfFont(DEFAULT_PDF_FONT).register(pdfMake);
-    })();
+async function ensurePdfMakeFontsRegistered(
+  pdfMake: PdfMakeFontRuntime,
+  fontId: PdfFontId
+): Promise<void> {
+  const existing = fontRegistrationPromises.get(fontId);
+  if (existing) {
+    return existing;
   }
 
-  return fontRegistrationPromise;
+  const registration = getPdfFont(fontId).register(pdfMake);
+  fontRegistrationPromises.set(fontId, registration);
+  return registration;
 }
 
 function getFilename(resume: ResumeSchema): string {
@@ -103,7 +107,7 @@ export async function exportPDF(
   };
   const selectedFont = getPdfFont(options.font ?? DEFAULT_PDF_FONT);
 
-  await ensurePdfMakeFontsRegistered(pdfMake);
+  await ensurePdfMakeFontsRegistered(pdfMake, selectedFont.id);
 
   const docDef = await getDocDef(validation.normalizedResume, template, {
     accentColor: options.accentColor,

--- a/src/store/resume.ts
+++ b/src/store/resume.ts
@@ -2,6 +2,7 @@ import { createSignal } from "solid-js";
 import { createStore } from "solid-js/store";
 
 import { DEFAULT_RESUME_ACCENT_COLOR } from "@/lib/resume/design";
+import { DEFAULT_PDF_FONT, type PdfFontId } from "@/lib/export/fonts";
 import { normalizeResume } from "@/lib/resume/normalize";
 import { DEFAULT_TEMPLATE_ID, type TemplateId } from "@/types/template";
 import { EMPTY_RESUME } from "@/types/resume";
@@ -18,6 +19,8 @@ export const [selectedTemplate, setSelectedTemplate] =
 export const [selectedAccentColor, setSelectedAccentColor] = createSignal(
   DEFAULT_RESUME_ACCENT_COLOR
 );
+
+export const [selectedFontId, setSelectedFontId] = createSignal<PdfFontId>(DEFAULT_PDF_FONT);
 
 export const [activeSection, setActiveSection] = createSignal<SectionId>("basics");
 


### PR DESCRIPTION
## Summary
Adds first-class global design controls for accent color and typography in the preview surface. The chosen accent and font now apply to both the on-screen preview and exported PDF output, using a small curated font list that includes non-default PDF-safe options.

## Changes
- add global editor state for the selected PDF-safe font alongside the existing accent color state
- expand the PDF font registry with curated Helvetica and Times options and use the selected font during export
- add accent color and font controls to the preview toolbar and apply the selected typography to the live preview

## Testing
- [x] bun run verify
- [x] bun run test -- src/lib/export/pdf-export.test.ts

## References
- Ticket/Issue: Fixes #16