### PR TITLE
feat: add classic and signal resume templates

### DIFF
--- a/src/components/resume/ResumeDocument.tsx
+++ b/src/components/resume/ResumeDocument.tsx
@@ -15,7 +15,7 @@ function renderSectionTitle(
   template: ResumeDesignSettings["template"],
   accentColor: string
 ) {
-  if (template === "modern") {
+  if (template === "modern" || template === "signal") {
     return (
       <h2
         class="resume-document__section-title mb-1 border-b pb-0.5 text-xs font-bold uppercase tracking-widest"
@@ -109,7 +109,7 @@ const ResumeDocument: Component<ResumeDocumentProps> = (props) => {
 
   const model = () => buildResumeRenderModel(local.resume, local.design);
   const headerClass = () =>
-    local.design.template === "modern"
+    local.design.template === "modern" || local.design.template === "signal"
       ? "resume-document__header mb-4 border-b-2 pb-3"
       : local.design.template === "compact-ats"
         ? "resume-document__header mb-2"
@@ -130,7 +130,9 @@ const ResumeDocument: Component<ResumeDocumentProps> = (props) => {
       <div
         class={headerClass()}
         style={
-          local.design.template === "modern" ? { "border-color": local.design.accentColor } : {}
+          local.design.template === "modern" || local.design.template === "signal"
+            ? { "border-color": local.design.accentColor }
+            : {}
         }
       >
         <h1 class={nameClass()}>{model().header.name || "Your Name"}</h1>

--- a/src/lib/export/pdf-renderer.ts
+++ b/src/lib/export/pdf-renderer.ts
@@ -131,7 +131,7 @@ export function renderPdfResumeModel(
   model: ResumeRenderModel,
   options: PdfRenderOptions
 ): TDocumentDefinitions {
-  if (model.template === "modern") {
+  if (model.template === "modern" || model.template === "signal") {
     return {
       content: [
         {

--- a/src/lib/templates/classic.test.ts
+++ b/src/lib/templates/classic.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveResumeDesignSettings } from "@/lib/resume/design";
+
+import { buildClassicRenderModel, classicTemplate } from "./classic";
+import { createTemplateFixture } from "./template-fixtures";
+
+describe("classicTemplate", () => {
+  it("creates a conservative render model with classic section ordering", () => {
+    const model = buildClassicRenderModel(
+      createTemplateFixture(),
+      resolveResumeDesignSettings({ template: "classic", accentColor: "#1d6648" })
+    );
+
+    expect(model.sections.map((section) => section.id)).toEqual([
+      "summary",
+      "work",
+      "education",
+      "certificates",
+      "skills",
+      "projects",
+    ]);
+  });
+
+  it("emits a valid document definition", () => {
+    const doc = classicTemplate(createTemplateFixture(), { fontFamily: "Roboto" });
+    const serialized = JSON.stringify(doc);
+
+    expect(serialized).toContain("PROFESSIONAL EXPERIENCE");
+    expect(serialized).toContain("SELECTED PROJECTS");
+  });
+});

--- a/src/lib/templates/classic.ts
+++ b/src/lib/templates/classic.ts
@@ -1,0 +1,117 @@
+import type { ResumeSchema } from "@/types/resume";
+import type { TDocumentDefinitions } from "pdfmake/interfaces";
+
+import {
+  formatContactLine,
+  formatDisplayUrl,
+  formatInterestsText,
+  formatLanguagesText,
+  formatSkillsText,
+} from "@/lib/export/template-helpers";
+import { renderPdfResumeModel } from "@/lib/export/pdf-renderer";
+import type { PdfTemplateOptions } from "@/lib/export/template-types";
+import {
+  resolvePageMargins,
+  resolveResumeDesignSettings,
+  type ResumeDesignSettings,
+} from "@/lib/resume/design";
+import type { ResumeRenderModel, ResumeSectionModel } from "@/lib/templates/render-model";
+import {
+  buildAwardsSection,
+  buildCertificatesSection,
+  buildEducationSection,
+  buildProjectsSection,
+  buildPublicationsSection,
+  buildReferencesSection,
+  buildTextSection,
+  buildVolunteerSection,
+  buildWorkSection,
+} from "@/lib/templates/section-builders";
+
+const PAGE_MARGINS = [52, 52, 52, 52] as const;
+
+export function buildClassicRenderModel(
+  resume: ResumeSchema,
+  design: ResumeDesignSettings
+): ResumeRenderModel {
+  const sections: ResumeSectionModel[] = [];
+  const skillsText = formatSkillsText(resume.skills, { groupSeparator: ", " });
+  const languagesText = formatLanguagesText(resume.languages, { groupSeparator: ", " });
+  const interestsText = formatInterestsText(resume.interests, { groupSeparator: ", " });
+
+  const appendSection = (section: ResumeSectionModel | null) => {
+    if (section) sections.push(section);
+  };
+
+  appendSection(
+    buildTextSection({ id: "summary", title: "Professional Summary", text: resume.basics.summary })
+  );
+  appendSection(
+    buildWorkSection(resume.work, { title: "Professional Experience", subtitleMode: "inline" })
+  );
+  appendSection(
+    buildEducationSection(resume.education, { title: "Education", subtitleMode: "inline" })
+  );
+  appendSection(
+    buildCertificatesSection(resume.certificates, {
+      title: "Certifications",
+      subtitleMode: "inline",
+    })
+  );
+  appendSection(buildTextSection({ id: "skills", title: "Skills", text: skillsText }));
+  appendSection(buildProjectsSection(resume.projects, { title: "Selected Projects" }));
+  appendSection(
+    buildVolunteerSection(resume.volunteer, {
+      title: "Volunteer Experience",
+      subtitleMode: "inline",
+    })
+  );
+  appendSection(buildAwardsSection(resume.awards, { title: "Awards", subtitleMode: "inline" }));
+  appendSection(
+    buildPublicationsSection(resume.publications, {
+      title: "Publications",
+      subtitleMode: "inline",
+      resolveLink: (url) => formatDisplayUrl(url),
+    })
+  );
+  appendSection(buildTextSection({ id: "languages", title: "Languages", text: languagesText }));
+  appendSection(buildTextSection({ id: "interests", title: "Interests", text: interestsText }));
+  appendSection(buildReferencesSection(resume.references, { title: "References" }));
+
+  return {
+    template: "classic",
+    design,
+    pageMargins: resolvePageMargins(design, [...PAGE_MARGINS]),
+    header: {
+      name: resume.basics.name,
+      label: resume.basics.label,
+      contactLine: formatContactLine(resume.basics, {
+        includeEmail: true,
+        includeLocation: true,
+        includePhone: true,
+      }),
+      urlLine: formatDisplayUrl(resume.basics.url),
+    },
+    sections,
+  };
+}
+
+export function classicTemplate(
+  resume: ResumeSchema,
+  options: PdfTemplateOptions
+): TDocumentDefinitions {
+  const design = resolveResumeDesignSettings({
+    template: "classic",
+    accentColor: options.accentColor,
+    pageFormat: options.pageFormat,
+    pageMargins: options.pageMargins,
+    typography: {
+      ...options.typography,
+      pdfFontFamily: options.fontFamily,
+    },
+  });
+
+  return renderPdfResumeModel(buildClassicRenderModel(resume, design), {
+    fontFamily: options.fontFamily,
+  });
+}

--- a/src/lib/templates/registry.ts
+++ b/src/lib/templates/registry.ts
@@ -3,9 +3,11 @@ import type { TDocumentDefinitions } from "pdfmake/interfaces";
 import type { PdfTemplateOptions } from "@/lib/export/template-types";
 import type { ResumeDesignSettings } from "@/lib/resume/design";
 import type { ResumeSchema } from "@/types/resume";
+import { buildClassicRenderModel, classicTemplate } from "@/lib/templates/classic";
 import { buildCompactAtsRenderModel, compactAtsTemplate } from "@/lib/templates/compact-ats";
 import { buildMinimalRenderModel, minimalTemplate } from "@/lib/templates/minimal";
 import { buildModernRenderModel, modernTemplate } from "@/lib/templates/modern";
+import { buildSignalRenderModel, signalTemplate } from "@/lib/templates/signal";
 import type { ResumeRenderModel } from "@/lib/templates/render-model";
 import { TEMPLATE_IDS, type TemplateId } from "@/types/template";
 
@@ -51,6 +53,20 @@ export const TEMPLATE_REGISTRY = {
     description: "Dense, keyword-optimized",
     buildRenderModel: buildCompactAtsRenderModel,
     renderPdf: compactAtsTemplate,
+  },
+  classic: {
+    id: "classic",
+    label: "Classic",
+    description: "Traditional ordering, formal headings",
+    buildRenderModel: buildClassicRenderModel,
+    renderPdf: classicTemplate,
+  },
+  signal: {
+    id: "signal",
+    label: "Signal",
+    description: "Skills-forward, sharper emphasis",
+    buildRenderModel: buildSignalRenderModel,
+    renderPdf: signalTemplate,
   },
 } satisfies Record<TemplateId, TemplateRegistryEntry>;
 

--- a/src/lib/templates/signal.test.ts
+++ b/src/lib/templates/signal.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveResumeDesignSettings } from "@/lib/resume/design";
+
+import { buildSignalRenderModel, signalTemplate } from "./signal";
+import { createTemplateFixture } from "./template-fixtures";
+
+describe("signalTemplate", () => {
+  it("creates a differentiated render model with skills and projects up front", () => {
+    const model = buildSignalRenderModel(
+      createTemplateFixture(),
+      resolveResumeDesignSettings({ template: "signal", accentColor: "#1d6648" })
+    );
+
+    expect(model.sections.map((section) => section.id)).toEqual([
+      "skills",
+      "summary",
+      "work",
+      "projects",
+      "education",
+      "certificates",
+    ]);
+  });
+
+  it("emits a valid document definition", () => {
+    const doc = signalTemplate(createTemplateFixture(), { fontFamily: "Roboto" });
+    const serialized = JSON.stringify(doc);
+
+    expect(serialized).toContain("CORE SKILLS");
+    expect(serialized).toContain("SELECTED PROJECTS");
+  });
+});

--- a/src/lib/templates/signal.ts
+++ b/src/lib/templates/signal.ts
@@ -1,0 +1,139 @@
+import type { ResumeSchema } from "@/types/resume";
+import type { TDocumentDefinitions } from "pdfmake/interfaces";
+
+import {
+  buildProjectMetadata,
+  formatContactLine,
+  formatDisplayUrl,
+  formatInterestsText,
+  formatLanguagesText,
+  formatSkillsText,
+} from "@/lib/export/template-helpers";
+import { renderPdfResumeModel } from "@/lib/export/pdf-renderer";
+import type { PdfTemplateOptions } from "@/lib/export/template-types";
+import {
+  resolvePageMargins,
+  resolveResumeDesignSettings,
+  type ResumeDesignSettings,
+} from "@/lib/resume/design";
+import type { ResumeRenderModel, ResumeSectionModel } from "@/lib/templates/render-model";
+import {
+  buildAwardsSection,
+  buildCertificatesSection,
+  buildEducationSection,
+  buildProjectsSection,
+  buildPublicationsSection,
+  buildReferencesSection,
+  buildTextSection,
+  buildVolunteerSection,
+  buildWorkSection,
+} from "@/lib/templates/section-builders";
+
+const PAGE_MARGINS = [42, 42, 42, 42] as const;
+
+export function buildSignalRenderModel(
+  resume: ResumeSchema,
+  design: ResumeDesignSettings
+): ResumeRenderModel {
+  const sections: ResumeSectionModel[] = [];
+  const skillsText = formatSkillsText(resume.skills, { groupSeparator: " • " });
+  const languagesText = formatLanguagesText(resume.languages, { groupSeparator: " • " });
+  const interestsText = formatInterestsText(resume.interests, { groupSeparator: " • " });
+
+  const appendSection = (section: ResumeSectionModel | null) => {
+    if (section) sections.push(section);
+  };
+
+  appendSection(buildTextSection({ id: "skills", title: "Core Skills", text: skillsText }));
+  appendSection(buildTextSection({ id: "summary", title: "Profile", text: resume.basics.summary }));
+  appendSection(
+    buildWorkSection(resume.work, {
+      title: "Experience",
+      subtitleMode: "stacked",
+      spacerAfter: 6,
+    })
+  );
+  appendSection(
+    buildProjectsSection(resume.projects, {
+      title: "Selected Projects",
+      spacerAfter: 4,
+      resolveMeta: (project) => buildProjectMetadata(project),
+      resolveLink: (url) => (url ? (formatDisplayUrl(url) ?? url) : undefined),
+    })
+  );
+  appendSection(
+    buildEducationSection(resume.education, {
+      title: "Education",
+      subtitleMode: "stacked",
+      spacerAfter: 4,
+    })
+  );
+  appendSection(
+    buildCertificatesSection(resume.certificates, {
+      title: "Certifications",
+      subtitleMode: "stacked",
+    })
+  );
+  appendSection(
+    buildVolunteerSection(resume.volunteer, {
+      title: "Volunteer",
+      subtitleMode: "stacked",
+      spacerAfter: 4,
+    })
+  );
+  appendSection(
+    buildAwardsSection(resume.awards, {
+      title: "Awards",
+      subtitleMode: "stacked",
+      spacerAfter: 4,
+    })
+  );
+  appendSection(
+    buildPublicationsSection(resume.publications, {
+      title: "Publications",
+      subtitleMode: "stacked",
+      spacerAfter: 4,
+      resolveLink: (url) => (url ? (formatDisplayUrl(url) ?? url) : undefined),
+    })
+  );
+  appendSection(buildTextSection({ id: "languages", title: "Languages", text: languagesText }));
+  appendSection(buildTextSection({ id: "interests", title: "Interests", text: interestsText }));
+  appendSection(buildReferencesSection(resume.references, { title: "References", spacerAfter: 4 }));
+
+  return {
+    template: "signal",
+    design,
+    pageMargins: resolvePageMargins(design, [...PAGE_MARGINS]),
+    header: {
+      name: resume.basics.name,
+      label: resume.basics.label,
+      contactLine: formatContactLine(resume.basics, {
+        includeEmail: true,
+        includeLocation: true,
+        includePhone: true,
+      }),
+      urlLine: formatDisplayUrl(resume.basics.url),
+    },
+    sections,
+  };
+}
+
+export function signalTemplate(
+  resume: ResumeSchema,
+  options: PdfTemplateOptions
+): TDocumentDefinitions {
+  const design = resolveResumeDesignSettings({
+    template: "signal",
+    accentColor: options.accentColor,
+    pageFormat: options.pageFormat,
+    pageMargins: options.pageMargins,
+    typography: {
+      ...options.typography,
+      pdfFontFamily: options.fontFamily,
+    },
+  });
+
+  return renderPdfResumeModel(buildSignalRenderModel(resume, design), {
+    fontFamily: options.fontFamily,
+  });
+}

--- a/src/types/template.ts
+++ b/src/types/template.ts
@@ -1,4 +1,4 @@
-export const TEMPLATE_IDS = ["modern", "minimal", "compact-ats"] as const;
+export const TEMPLATE_IDS = ["modern", "minimal", "compact-ats", "classic", "signal"] as const;
 
 export type TemplateId = (typeof TEMPLATE_IDS)[number];
 


### PR DESCRIPTION
## Summary
Adds two new resume templates on top of the shared template primitives from #55: a more traditional Classic option and a more skills-forward Signal option. Both reuse the shared render-model layer so preview and export stay aligned without copying large section-mapping blocks.

## Changes
- add new Classic and Signal template builders and register them in the shared template registry
- reuse the shared section-builder primitives to keep section mapping logic centralized across all templates
- extend preview/PDF rendering so the new templates appear in the picker and render correctly in both preview and export

## Testing
- [x] bun run verify
- [x] bun run test -- src/lib/templates/classic.test.ts src/lib/templates/signal.test.ts src/lib/templates/registry.test.ts

## References
- Ticket/Issue: Fixes #12